### PR TITLE
Cleanup IServiceProvider (as service locator usage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,26 @@ Basic Architecture within the SDK
 +---------+
 ````
 
+
+DI Container Elements
+
+````
+                                              PoweredUpHost +----+
+                                                   +             |
+                                                   |             |
++-------------------- Scoped Service Provider ---------------------+
+|                                                  |             | |
+|                                                  v             +--->IPoweredUp
+| LinearMidCalibration +                         HubFactory      | |  BluetoothAdapter
+|                      |                                         | |
+| TechnicMediumHub +---+-> PoweredUpProtocol +-> BluetoothKernel + |
+|             +                       +                            |
+|             |                       |                            |
+|             +-----------------------+--------> DeviceFactory     |
+|                                                                  |
++------------------------------------------------------------------+
+````
+
 ## Implementation Status
 
 - Bluetooth Adapter

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleBluetoothByKnownAddress.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleBluetoothByKnownAddress.cs
@@ -12,9 +12,9 @@ namespace Example
         // device needs to be switched on!
         public override async Task DiscoverAsync(bool enableTrace)
         {
-            var hub = host.Create<TechnicMediumHub>(ChangeMe_BluetoothAddress);
+            var hub = Host.Create<TechnicMediumHub>(ChangeMe_BluetoothAddress);
 
-            selectedHub = DirectlyConnectedHub = hub;
+            SelectedHub = DirectlyConnectedHub = hub;
 
             await hub.ConnectAsync();
         }

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleBluetoothByName.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleBluetoothByName.cs
@@ -10,7 +10,7 @@ namespace Example
 
         public override async Task ExecuteAsync()
         {
-            using (var technicMediumHub = host.FindByName<TechnicMediumHub>("Technic Hub"))
+            using (var technicMediumHub = Host.FindByName<TechnicMediumHub>("Technic Hub"))
             {
                 await technicMediumHub.RgbLight.SetRgbColorsAsync(0xff, 0x00, 0x00);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleCalibrationSteering.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleCalibrationSteering.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using SharpBrick.PoweredUp;
+using SharpBrick.PoweredUp.Functions;
+using static SharpBrick.PoweredUp.Directions;
+
+namespace Example
+{
+    public class ExampleCalibrationSteering : BaseExample
+    {
+        public override async Task ExecuteAsync()
+        {
+            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            {
+                var motor = technicMediumHub.A.GetDevice<TechnicLargeLinearMotor>();
+
+                var calibration = new LinearMidCalibration(serviceProvider);
+                await calibration.ExecuteAsync(motor);
+
+                await Task.Delay(5000);
+                await motor.GotoAbsolutePositionAsync(CW * 50, 20, 100, SpecialSpeed.Hold, SpeedProfiles.AccelerationProfile);
+                await Task.Delay(5000);
+                await motor.GotoAbsolutePositionAsync(CCW * 50, 20, 100, SpecialSpeed.Hold, SpeedProfiles.AccelerationProfile);
+                await Task.Delay(5000);
+
+                await technicMediumHub.SwitchOffAsync();
+            }
+        }
+
+
+    }
+}

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleCalibrationSteering.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleCalibrationSteering.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using SharpBrick.PoweredUp;
 using SharpBrick.PoweredUp.Functions;
 using static SharpBrick.PoweredUp.Directions;
@@ -13,7 +14,7 @@ namespace Example
             {
                 var motor = technicMediumHub.A.GetDevice<TechnicLargeLinearMotor>();
 
-                var calibration = new LinearMidCalibration(serviceProvider);
+                var calibration = serviceProvider.GetService<LinearMidCalibration>();
                 await calibration.ExecuteAsync(motor);
 
                 await Task.Delay(5000);

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleCalibrationSteering.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleCalibrationSteering.cs
@@ -10,11 +10,11 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 var motor = technicMediumHub.A.GetDevice<TechnicLargeLinearMotor>();
 
-                var calibration = serviceProvider.GetService<LinearMidCalibration>();
+                var calibration = ServiceProvider.GetService<LinearMidCalibration>();
                 await calibration.ExecuteAsync(motor);
 
                 await Task.Delay(5000);

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleColors.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleColors.cs
@@ -8,7 +8,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 await technicMediumHub.RgbLight.SetRgbColorsAsync(0x00, 0xff, 0x00);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleDiscoverByType.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleDiscoverByType.cs
@@ -11,9 +11,9 @@ namespace Example
         // device needs to be switched on!
         public override async Task DiscoverAsync(bool enableTrace)
         {
-            var hub = await host.DiscoverAsync<TechnicMediumHub>();
+            var hub = await Host.DiscoverAsync<TechnicMediumHub>();
 
-            selectedHub = DirectlyConnectedHub = hub;
+            SelectedHub = DirectlyConnectedHub = hub;
 
             await hub.ConnectAsync();
         }

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleDynamicDevice.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleDynamicDevice.cs
@@ -30,9 +30,7 @@ namespace Example
 
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleDynamicDevice>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 // deployment model verification with unknown devices
                 await technicMediumHub.VerifyDeploymentModelAsync(mb => mb
@@ -47,7 +45,7 @@ namespace Example
 
                 // discover the unknown device using the LWP
                 await dynamicDeviceWhichIsAMotor.DiscoverAsync();
-                logger.LogInformation("Discovery completed");
+                Log.LogInformation("Discovery completed");
 
                 // use combined mode values from the device
                 await dynamicDeviceWhichIsAMotor.TryLockDeviceForCombinedModeNotificationSetupAsync(2, 3);
@@ -61,8 +59,8 @@ namespace Example
                 var aposMode = dynamicDeviceWhichIsAMotor.SingleValueMode<short>(3);
 
                 // use their observables to report values
-                using var disposable = posMode.Observable.Subscribe(x => logger.LogWarning($"Position: {x.SI} / {x.Pct}"));
-                using var disposable2 = aposMode.Observable.Subscribe(x => logger.LogWarning($"Absolute Position: {x.SI} / {x.Pct}"));
+                using var disposable = posMode.Observable.Subscribe(x => Log.LogWarning($"Position: {x.SI} / {x.Pct}"));
+                using var disposable2 = aposMode.Observable.Subscribe(x => Log.LogWarning($"Absolute Position: {x.SI} / {x.Pct}"));
 
                 // or even write to them
                 await powerMode.WriteDirectModeDataAsync(0x64); // That is StartPower on a motor

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleHubActions.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleHubActions.cs
@@ -8,7 +8,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 await technicMediumHub.RgbLight.SetRgbColorsAsync(0x00, 0xff, 0xff);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleHubAlert.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleHubAlert.cs
@@ -8,7 +8,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 technicMediumHub.AlertObservable.Subscribe(x => Console.WriteLine($"Alert: {x}"));
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleHubPropertyObserving.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleHubPropertyObserving.cs
@@ -10,12 +10,10 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleSetHubProperty>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
-                using var d1 = technicMediumHub.ButtonObservable.Subscribe(x => logger.LogInformation($"Buttom: {x}"));
-                technicMediumHub.PropertyChanged += (sender, ea) => { logger.LogInformation($"Change on Property {ea.PropertyName}"); };
+                using var d1 = technicMediumHub.ButtonObservable.Subscribe(x => Log.LogInformation($"Buttom: {x}"));
+                technicMediumHub.PropertyChanged += (sender, ea) => { Log.LogInformation($"Change on Property {ea.PropertyName}"); };
 
                 // optionally: trigger explicit request (like done during initialization)
                 await technicMediumHub.RequestHubPropertySingleUpdate(HubProperty.Button);
@@ -26,7 +24,7 @@ namespace Example
                 await Task.Delay(5_000);
 
                 await technicMediumHub.SetupHubPropertyNotificationAsync(HubProperty.Button, false);
-                logger.LogInformation("Button no longer observed");
+                Log.LogInformation("Button no longer observed");
 
                 await Task.Delay(5_000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleMixedBag.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleMixedBag.cs
@@ -12,9 +12,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 await technicMediumHub.VerifyDeploymentModelAsync(modelBuilder => modelBuilder
                     .AddHub<TechnicMediumHub>(hubBuilder => hubBuilder
@@ -26,7 +24,7 @@ namespace Example
 
                 technicMediumHub.Current.CurrentLObservable.Subscribe(v =>
                 {
-                    logger.LogWarning($"Current: {v.Pct}% {v.SI}mA / {technicMediumHub.Current.CurrentL}mA");
+                    Log.LogWarning($"Current: {v.Pct}% {v.SI}mA / {technicMediumHub.Current.CurrentL}mA");
                 });
 
                 await technicMediumHub.Current.SetupNotificationAsync(0x00, true, 1);

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleMotorControl.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleMotorControl.cs
@@ -8,7 +8,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 await technicMediumHub.VerifyDeploymentModelAsync(modelBuilder => modelBuilder
                     .AddHub<TechnicMediumHub>(hubBuilder => hubBuilder

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleMotorInputAbsolutePosition.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleMotorInputAbsolutePosition.cs
@@ -11,9 +11,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 await technicMediumHub.VerifyDeploymentModelAsync(modelBuilder => modelBuilder
                     .AddHub<TechnicMediumHub>(hubBuilder => hubBuilder
@@ -37,9 +35,9 @@ namespace Example
                 await motor.SetupNotificationAsync(motor.ModeIndexPosition, true);
                 await motor.UnlockFromCombinedModeNotificationSetupAsync(true);
 
-                using var disposable = motor.AbsolutePositionObservable.Subscribe(x => logger.LogWarning($"Absolute Position: {x.SI} / {x.Pct}"));
-                using var disposable2 = motor.PositionObservable.Subscribe(x => logger.LogWarning($"Position: {x.SI} / {x.Pct}"));
-                motor.PropertyChanged += (sender, ea) => { logger.LogInformation($"Change on Property {ea.PropertyName}"); };
+                using var disposable = motor.AbsolutePositionObservable.Subscribe(x => Log.LogWarning($"Absolute Position: {x.SI} / {x.Pct}"));
+                using var disposable2 = motor.PositionObservable.Subscribe(x => Log.LogWarning($"Position: {x.SI} / {x.Pct}"));
+                motor.PropertyChanged += (sender, ea) => { Log.LogInformation($"Change on Property {ea.PropertyName}"); };
 
                 // relative movement from current positions
                 await technicMediumHub.RgbLight.SetRgbColorNoAsync(PoweredUpColor.Pink);

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleMotorInputCombinedMode.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleMotorInputCombinedMode.cs
@@ -11,9 +11,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputCombinedMode>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 await technicMediumHub.VerifyDeploymentModelAsync(modelBuilder => modelBuilder
                     .AddHub<TechnicMediumHub>(hubBuilder => hubBuilder
@@ -33,15 +31,15 @@ namespace Example
 
                 await motor.StartPowerAsync(80);
 
-                var disposable1 = motor.SpeedObservable.Subscribe(x => logger.LogWarning($"Speed: {x.SI} / {x.Pct}"));
+                var disposable1 = motor.SpeedObservable.Subscribe(x => Log.LogWarning($"Speed: {x.SI} / {x.Pct}"));
 
-                var disposable2 = motor.PositionObservable.Subscribe(x => logger.LogWarning($"Position: {x.SI} / {x.Pct}"));
+                var disposable2 = motor.PositionObservable.Subscribe(x => Log.LogWarning($"Position: {x.SI} / {x.Pct}"));
 
-                var disposable3 = motor.AbsolutePositionObservable.Subscribe(x => logger.LogWarning($"Absolute Position: {x.SI} / {x.Pct}"));
+                var disposable3 = motor.AbsolutePositionObservable.Subscribe(x => Log.LogWarning($"Absolute Position: {x.SI} / {x.Pct}"));
 
                 await Task.Delay(2000);
 
-                logger.LogWarning($"Position: {motor.AbsolutePosition}");
+                Log.LogWarning($"Position: {motor.AbsolutePosition}");
 
                 await Task.Delay(2000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleMotorVirtualPort.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleMotorVirtualPort.cs
@@ -8,7 +8,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 await technicMediumHub.VerifyDeploymentModelAsync(modelBuilder => modelBuilder
                     .AddHub<TechnicMediumHub>(hubBuilder => hubBuilder

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleSetHubProperty.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleSetHubProperty.cs
@@ -10,28 +10,26 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleSetHubProperty>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
-                using var d1 = technicMediumHub.AdvertisementNameObservable.Subscribe(x => logger.LogInformation($"From Observable for AdvertisementName: {x}"));
-                using var d2 = technicMediumHub.PropertyChangedObservable.Subscribe(x => logger.LogInformation($"Property Changed: {x}"));
+                using var d1 = technicMediumHub.AdvertisementNameObservable.Subscribe(x => Log.LogInformation($"From Observable for AdvertisementName: {x}"));
+                using var d2 = technicMediumHub.PropertyChangedObservable.Subscribe(x => Log.LogInformation($"Property Changed: {x}"));
 
                 var originalName = technicMediumHub.AdvertisingName;
 
-                logger.LogInformation($"Original Name: {originalName}");
+                Log.LogInformation($"Original Name: {originalName}");
 
                 await technicMediumHub.SetAdvertisingNameAsync("Hello World");
 
-                logger.LogInformation($"New Name is: {technicMediumHub.AdvertisingName}");
+                Log.LogInformation($"New Name is: {technicMediumHub.AdvertisingName}");
 
                 await technicMediumHub.ResetAdvertisingNameAsync();
 
-                logger.LogInformation($"Resetted Name is: {technicMediumHub.AdvertisingName}");
+                Log.LogInformation($"Resetted Name is: {technicMediumHub.AdvertisingName}");
 
                 await technicMediumHub.SetAdvertisingNameAsync(originalName);
 
-                logger.LogInformation($"Name Cleanup to: {originalName}");
+                Log.LogInformation($"Name Cleanup to: {originalName}");
 
                 await technicMediumHub.SwitchOffAsync();
             }

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubAccelerometer.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubAccelerometer.cs
@@ -11,15 +11,13 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 var device = technicMediumHub.Accelerometer;
 
                 await device.SetupNotificationAsync(device.ModeIndexGravity, true);
 
-                var disposable = device.GravityObservable.Subscribe(x => logger.LogWarning($"Gravity: {x.x} / {x.y} / {x.z}"));
+                var disposable = device.GravityObservable.Subscribe(x => Log.LogWarning($"Gravity: {x.x} / {x.y} / {x.z}"));
 
                 await Task.Delay(10_000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubGyroSensor.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubGyroSensor.cs
@@ -11,15 +11,13 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 var device = technicMediumHub.GyroSensor;
 
                 await device.SetupNotificationAsync(device.ModeIndexRotation, true);
 
-                var disposable = device.RotationObservable.Subscribe(x => logger.LogWarning($"Rotation: {x.x} / {x.y} / {x.z}"));
+                var disposable = device.RotationObservable.Subscribe(x => Log.LogWarning($"Rotation: {x.x} / {x.y} / {x.z}"));
 
                 await Task.Delay(10_000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubTiltSensor.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubTiltSensor.cs
@@ -11,9 +11,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 var device = technicMediumHub.TiltSensor;
 
@@ -21,7 +19,7 @@ namespace Example
 
                 await device.SetupNotificationAsync(device.ModeIndexPosition, true);
 
-                using var disposable = device.PositionObservable.Subscribe(x => logger.LogWarning($"Tilt: {x.x} / {x.y} / {x.z}"));
+                using var disposable = device.PositionObservable.Subscribe(x => Log.LogWarning($"Tilt: {x.x} / {x.y} / {x.z}"));
 
                 await Task.Delay(10_000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubTiltSensorImpacts.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumHubTiltSensorImpacts.cs
@@ -11,9 +11,7 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 var device = technicMediumHub.TiltSensor;
 
@@ -21,7 +19,7 @@ namespace Example
 
                 await device.SetupNotificationAsync(device.ModeIndexImpacts, true, deltaInterval: 1);
 
-                using var disposable = device.ImpactsObservable.Subscribe(x => logger.LogWarning($"Impact: {x.SI} / {x.Pct} / {x.Raw}"));
+                using var disposable = device.ImpactsObservable.Subscribe(x => Log.LogWarning($"Impact: {x.SI} / {x.Pct} / {x.Raw}"));
 
                 await Task.Delay(10_000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumTemperatureSensor.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleTechnicMediumTemperatureSensor.cs
@@ -11,21 +11,19 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 var device1 = technicMediumHub.Temperature1;
 
                 await device1.SetupNotificationAsync(device1.ModeIndexTemperature, true);
 
-                var disposable1 = device1.TemperatureObservable.Subscribe(x => logger.LogWarning($"Temperature 1: {x.SI}° ({x.Pct}%)"));
+                var disposable1 = device1.TemperatureObservable.Subscribe(x => Log.LogWarning($"Temperature 1: {x.SI}° ({x.Pct}%)"));
 
                 var device2 = technicMediumHub.Temperature1;
 
                 await device2.SetupNotificationAsync(device2.ModeIndexTemperature, true);
 
-                var disposable2 = device2.TemperatureObservable.Subscribe(x => logger.LogWarning($"Temperature 2: {x.SI}° ({x.Pct}%)"));
+                var disposable2 = device2.TemperatureObservable.Subscribe(x => Log.LogWarning($"Temperature 2: {x.SI}° ({x.Pct}%)"));
 
                 await Task.Delay(10_000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleVoltage.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleVoltage.cs
@@ -11,15 +11,13 @@ namespace Example
     {
         public override async Task ExecuteAsync()
         {
-            var logger = serviceProvider.GetService<ILoggerFactory>().CreateLogger<ExampleMotorInputAbsolutePosition>();
-
-            using (var technicMediumHub = host.FindByType<TechnicMediumHub>())
+            using (var technicMediumHub = Host.FindByType<TechnicMediumHub>())
             {
                 var device = technicMediumHub.Voltage;
 
                 await device.SetupNotificationAsync(device.ModeIndexVoltageL, true);
 
-                var disposable = device.VoltageLObservable.Subscribe(x => logger.LogWarning($"Voltage L: {x.SI}mV ({x.Pct}%)"));
+                var disposable = device.VoltageLObservable.Subscribe(x => Log.LogWarning($"Voltage L: {x.SI}mV ({x.Pct}%)"));
 
                 await Task.Delay(10_000);
 

--- a/examples/SharpBrick.PoweredUp.Examples/Program.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/Program.cs
@@ -30,7 +30,8 @@ namespace SharpBrick.PoweredUp.Examples
             //example = new Example.ExampleBluetoothByName();
             //example = new Example.ExampleSetHubProperty();
             //example = new Example.ExampleHubPropertyObserving();
-            example = new Example.ExampleDiscoverByType();
+            //example = new Example.ExampleDiscoverByType();
+            example = new Example.ExampleCalibrationSteering();
 
             await example.InitHostAndDiscoverAsync(enableTrace);
 

--- a/examples/SharpBrick.PoweredUp.Examples/Program.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/Program.cs
@@ -9,6 +9,7 @@ namespace SharpBrick.PoweredUp.Examples
         {
             var enableTrace = (args.Length > 0 && args[0] == "--trace");
 
+            // NOTE: Examples are in their own root namespace to make namespace usage clear
             Example.BaseExample example;
 
             //example = new Example.ExampleColors();
@@ -33,9 +34,10 @@ namespace SharpBrick.PoweredUp.Examples
             //example = new Example.ExampleDiscoverByType();
             example = new Example.ExampleCalibrationSteering();
 
+            // NOTE: Examples are programmed object oriented style. Base class implements methods Configure, DiscoverAsync and ExecuteAsync to be overwriten on demand.
             await example.InitHostAndDiscoverAsync(enableTrace);
 
-            if (example.selectedHub != null)
+            if (example.SelectedHub != null)
             {
                 await example.ExecuteAsync();
             }

--- a/src/SharpBrick.PoweredUp.Cli/Commands/DevicesList.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Commands/DevicesList.cs
@@ -22,10 +22,10 @@ namespace SharpBrick.PoweredUp.Cli
                 .AddSingleton<ILoggerFactory>(loggerFactory)
                 .BuildServiceProvider();
 
-            using (var protocol = new PoweredUpProtocol(
-                new BluetoothKernel(poweredUpBluetoothAdapter, bluetoothAddress, loggerFactory.CreateLogger<BluetoothKernel>()),
-                serviceProvider))
+            using (var kernel = new BluetoothKernel(poweredUpBluetoothAdapter, loggerFactory.CreateLogger<BluetoothKernel>()))
+            using (var protocol = new PoweredUpProtocol(kernel, serviceProvider))
             {
+                kernel.BluetoothAddress = bluetoothAddress;
                 var discoverPorts = new DiscoverPorts(protocol, logger: loggerFactory.CreateLogger<DiscoverPorts>()); // register to upstream
 
                 if (enableTrace)

--- a/src/SharpBrick.PoweredUp.Cli/Commands/DumpStaticPortInfo.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Commands/DumpStaticPortInfo.cs
@@ -1,62 +1,47 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using SharpBrick.PoweredUp.Bluetooth;
 using SharpBrick.PoweredUp.Functions;
 using SharpBrick.PoweredUp.Protocol;
 using SharpBrick.PoweredUp.Protocol.Messages;
 using SharpBrick.PoweredUp.Utils;
-using SharpBrick.PoweredUp.WinRT;
 
 namespace SharpBrick.PoweredUp.Cli
 {
-    public static class DumpStaticPortInfo
+    public class DumpStaticPortInfo
     {
-        public static async Task ExecuteAsync(ILoggerFactory loggerFactory, WinRTPoweredUpBluetoothAdapter poweredUpBluetoothAdapter, ulong bluetoothAddress, byte portId, bool enableTrace)
+        private readonly IPoweredUpProtocol protocol;
+        private readonly DiscoverPorts discoverPorts;
+
+        public DumpStaticPortInfo(IPoweredUpProtocol protocol, DiscoverPorts discoverPorts)
         {
-            var serviceProvider = new ServiceCollection()
-                .AddSingleton<ILoggerFactory>(loggerFactory)
-                .BuildServiceProvider();
+            this.protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
+            this.discoverPorts = discoverPorts ?? throw new ArgumentNullException(nameof(discoverPorts));
+        }
+        public async Task ExecuteAsync(byte portId)
+        {
+            Console.WriteLine($"Discover Port {portId}. Receiving Messages ...");
 
+            await protocol.ConnectAsync(); // registering to bluetooth notification
 
-            using (var kernel = new BluetoothKernel(poweredUpBluetoothAdapter, loggerFactory.CreateLogger<BluetoothKernel>()))
-            using (var protocol = new PoweredUpProtocol(kernel, serviceProvider))
+            await Task.Delay(2000); // await ports to be announced initially by device.
+
+            using var disposable = protocol.UpstreamMessages.Subscribe(x => Console.Write("."));
+
+            await discoverPorts.ExecuteAsync(portId);
+
+            await protocol.SendMessageReceiveResultAsync<HubActionMessage>(new HubActionMessage() { HubId = 0, Action = HubAction.SwitchOffHub }, result => result.Action == HubAction.HubWillSwitchOff);
+
+            Console.WriteLine(string.Empty);
+
+            Console.WriteLine($"Discover Ports Function: {discoverPorts.ReceivedMessages} / {discoverPorts.SentMessages}");
+
+            Console.WriteLine("##################################################");
+            foreach (var data in discoverPorts.ReceivedMessagesData.OrderBy(x => x[2]).ThenBy(x => x[4]).ThenBy(x => (x.Length <= 5) ? -1 : x[5]))
             {
-                kernel.BluetoothAddress = bluetoothAddress;
-                var discoverPorts = new DiscoverPorts(protocol, logger: loggerFactory.CreateLogger<DiscoverPorts>());
-
-                if (enableTrace)
-                {
-                    var tracer = new TraceMessages(protocol, loggerFactory.CreateLogger<TraceMessages>());
-
-                    await tracer.ExecuteAsync();
-                }
-
-                Console.WriteLine($"Discover Port {portId}. Receiving Messages ...");
-
-                await protocol.ConnectAsync(); // registering to bluetooth notification
-
-                await Task.Delay(2000); // await ports to be announced initially by device.
-
-                using var disposable = protocol.UpstreamMessages.Subscribe(x => Console.Write("."));
-
-                await discoverPorts.ExecuteAsync(portId);
-
-                await protocol.SendMessageReceiveResultAsync<HubActionMessage>(new HubActionMessage() { HubId = 0, Action = HubAction.SwitchOffHub }, result => result.Action == HubAction.HubWillSwitchOff);
-
-                Console.WriteLine(string.Empty);
-
-                Console.WriteLine($"Discover Ports Function: {discoverPorts.ReceivedMessages} / {discoverPorts.SentMessages}");
-
-                Console.WriteLine("##################################################");
-                foreach (var data in discoverPorts.ReceivedMessagesData.OrderBy(x => x[2]).ThenBy(x => x[4]).ThenBy(x => (x.Length <= 5) ? -1 : x[5]))
-                {
-                    Console.WriteLine(BytesStringUtil.DataToString(data));
-                }
-                Console.WriteLine("##################################################");
+                Console.WriteLine(BytesStringUtil.DataToString(data));
             }
+            Console.WriteLine("##################################################");
         }
     }
 }

--- a/src/SharpBrick.PoweredUp.Cli/Commands/DumpStaticPortInfo.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Commands/DumpStaticPortInfo.cs
@@ -20,10 +20,11 @@ namespace SharpBrick.PoweredUp.Cli
                 .AddSingleton<ILoggerFactory>(loggerFactory)
                 .BuildServiceProvider();
 
-            using (var protocol = new PoweredUpProtocol(
-                new BluetoothKernel(poweredUpBluetoothAdapter, bluetoothAddress, loggerFactory.CreateLogger<BluetoothKernel>()),
-                serviceProvider))
+
+            using (var kernel = new BluetoothKernel(poweredUpBluetoothAdapter, loggerFactory.CreateLogger<BluetoothKernel>()))
+            using (var protocol = new PoweredUpProtocol(kernel, serviceProvider))
             {
+                kernel.BluetoothAddress = bluetoothAddress;
                 var discoverPorts = new DiscoverPorts(protocol, logger: loggerFactory.CreateLogger<DiscoverPorts>());
 
                 if (enableTrace)

--- a/src/SharpBrick.PoweredUp.Cli/Program.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Program.cs
@@ -34,17 +34,18 @@ namespace SharpBrick.PoweredUp.Cli
                     {
                         var enableTrace = bool.TryParse(traceOption.Value(), out var x) ? x : false;
 
+                        var serviceProvider = CreateServiceProvider(enableTrace);
+                        ulong bluetoothAddress = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
+
+                        if (bluetoothAddress == 0)
+                            return;
+
                         // initialize a DI scope per bluetooth connection / protocol (e.g. protocol is a per-bluetooth connection service)
-                        using (var scope = CreateServiceProvider(enableTrace).CreateScope())
+                        using (var scope = serviceProvider.CreateScope())
                         {
                             var scopedServiceProvider = scope.ServiceProvider;
 
                             await AddTraceWriterAsync(scopedServiceProvider, enableTrace);
-
-                            ulong bluetoothAddress = FindAndSelectHub(scopedServiceProvider.GetService<IPoweredUpBluetoothAdapter>());
-
-                            if (bluetoothAddress == 0)
-                                return;
 
                             scopedServiceProvider.GetService<BluetoothKernel>().BluetoothAddress = bluetoothAddress;
 
@@ -66,17 +67,18 @@ namespace SharpBrick.PoweredUp.Cli
                     {
                         var enableTrace = bool.TryParse(traceOption.Value(), out var x) ? x : false;
 
+                        var serviceProvider = CreateServiceProvider(enableTrace);
+                        ulong bluetoothAddress = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
+
+                        if (bluetoothAddress == 0)
+                            return;
+
                         // initialize a DI scope per bluetooth connection / protocol (e.g. protocol is a per-bluetooth connection service)
-                        using (var scope = CreateServiceProvider(enableTrace).CreateScope())
+                        using (var scope = serviceProvider.CreateScope())
                         {
                             var scopedServiceProvider = scope.ServiceProvider;
 
                             await AddTraceWriterAsync(scopedServiceProvider, enableTrace);
-
-                            ulong bluetoothAddress = FindAndSelectHub(scopedServiceProvider.GetService<IPoweredUpBluetoothAdapter>());
-
-                            if (bluetoothAddress == 0)
-                                return;
 
                             scopedServiceProvider.GetService<BluetoothKernel>().BluetoothAddress = bluetoothAddress;
 

--- a/src/SharpBrick.PoweredUp.Cli/Program.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Program.cs
@@ -48,7 +48,7 @@ namespace SharpBrick.PoweredUp.Cli
 
                             scopedServiceProvider.GetService<BluetoothKernel>().BluetoothAddress = bluetoothAddress;
 
-                            var deviceListCli = scopedServiceProvider.GetService<DevicesList>();
+                            var deviceListCli = scopedServiceProvider.GetService<DevicesList>(); // ServiceLocator ok: transient factory
 
                             await deviceListCli.ExecuteAsync();
                         }
@@ -80,7 +80,7 @@ namespace SharpBrick.PoweredUp.Cli
 
                             scopedServiceProvider.GetService<BluetoothKernel>().BluetoothAddress = bluetoothAddress;
 
-                            var dumpStaticPortInfoCommand = scopedServiceProvider.GetService<DumpStaticPortInfo>();
+                            var dumpStaticPortInfoCommand = scopedServiceProvider.GetService<DumpStaticPortInfo>(); // ServiceLocator ok: transient factory
 
                             var port = byte.Parse(portOption.Value());
 
@@ -122,7 +122,7 @@ namespace SharpBrick.PoweredUp.Cli
         {
             if (enableTrace)
             {
-                var traceMessages = serviceProvider.GetService<TraceMessages>();
+                var traceMessages = serviceProvider.GetService<TraceMessages>(); // ServiceLocator ok: transient factory
 
                 await traceMessages.ExecuteAsync();
             }

--- a/src/SharpBrick.PoweredUp.Cli/Program.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Program.cs
@@ -111,10 +111,6 @@ namespace SharpBrick.PoweredUp.Cli
                 .AddSingleton<IPoweredUpBluetoothAdapter, WinRTPoweredUpBluetoothAdapter>()
                 .AddPoweredUp()
 
-                // Add Functions
-                .AddTransient<DiscoverPorts>()
-                .AddTransient<TraceMessages>()
-
                 // Add CLI Commands
                 .AddTransient<DumpStaticPortInfo>()
                 .AddTransient<DevicesList>()

--- a/src/SharpBrick.PoweredUp/Bluetooth/BluetoothKernel.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/BluetoothKernel.cs
@@ -9,15 +9,14 @@ namespace SharpBrick.PoweredUp.Bluetooth
     {
         private readonly ILogger _logger;
         private readonly IPoweredUpBluetoothAdapter _bluetoothAdapter;
-        private readonly ulong _bluetoothAddress;
+        public ulong BluetoothAddress { get; set; }
         private IPoweredUpBluetoothDevice _device = null;
         private IPoweredUpBluetoothService _service = null;
         private IPoweredUpBluetoothCharacteristic _characteristic = null;
 
-        public BluetoothKernel(IPoweredUpBluetoothAdapter bluetoothAdapter, ulong bluetoothAddress, ILogger<BluetoothKernel> logger = default)
+        public BluetoothKernel(IPoweredUpBluetoothAdapter bluetoothAdapter, ILogger<BluetoothKernel> logger = default)
         {
             _bluetoothAdapter = bluetoothAdapter ?? throw new ArgumentNullException(nameof(bluetoothAdapter));
-            _bluetoothAddress = bluetoothAddress;
             _logger = logger;
         }
 
@@ -25,7 +24,7 @@ namespace SharpBrick.PoweredUp.Bluetooth
 
         public async Task ConnectAsync()
         {
-            _device = await _bluetoothAdapter.GetDeviceAsync(_bluetoothAddress);
+            _device = await _bluetoothAdapter.GetDeviceAsync(BluetoothAddress);
             _service = await _device.GetServiceAsync(new Guid(PoweredUpBluetoothConstants.LegoHubService));
             _characteristic = await _service.GetCharacteristicAsync(new Guid(PoweredUpBluetoothConstants.LegoHubCharacteristic));
 

--- a/src/SharpBrick.PoweredUp/Functions/DiscoverPorts.cs
+++ b/src/SharpBrick.PoweredUp/Functions/DiscoverPorts.cs
@@ -16,7 +16,6 @@ namespace SharpBrick.PoweredUp.Functions
         private readonly IPoweredUpProtocol _protocol;
         private readonly byte _hubId;
         private readonly ILogger<DiscoverPorts> _logger;
-        private readonly IDisposable _disposable;
         private TaskCompletionSource<int> _taskCompletionSource;
         private int _stageTwoCount;
         private int _stageTwoExpected;
@@ -110,7 +109,7 @@ namespace SharpBrick.PoweredUp.Functions
             {
                 var port = knowledge.Port(_hubId, msg.PortId);
 
-                RequestPortModePropertiesAsync(port);
+                _ = RequestPortModePropertiesAsync(port); // discard the task to supress the await error
             }
 
             if (applicableMessage)

--- a/src/SharpBrick.PoweredUp/Functions/LinearMidCalibration.cs
+++ b/src/SharpBrick.PoweredUp/Functions/LinearMidCalibration.cs
@@ -11,6 +11,9 @@ namespace SharpBrick.PoweredUp.Functions
     {
         private IServiceProvider _serviceProvider;
 
+        public byte MaxPower { get; set; } = 10;
+        public byte Speed { get; set; } = 10;
+
         public LinearMidCalibration(IServiceProvider serviceProvider)
         {
             this._serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
@@ -32,7 +35,7 @@ namespace SharpBrick.PoweredUp.Functions
             await motor.UnlockFromCombinedModeNotificationSetupAsync(true);
 
             logger.LogInformation("Start CW");
-            await motor.StartPowerAsync(CW * 10);
+            await motor.StartPowerAsync((sbyte)(CW * MaxPower));
 
             await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
             logger.LogInformation("Reached End by detecting no speed movement.");
@@ -41,7 +44,7 @@ namespace SharpBrick.PoweredUp.Functions
             logger.LogInformation($"CW End at {cwVal}.");
 
             logger.LogInformation("Start CCW");
-            await motor.StartPowerAsync(CCW * 10);
+            await motor.StartPowerAsync((sbyte)(CCW * MaxPower));
 
             await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
             logger.LogInformation("Reached End by detecting no speed movement.");
@@ -55,7 +58,7 @@ namespace SharpBrick.PoweredUp.Functions
             var extend = (uint)(range / 2);
             logger.LogInformation($"Total Range: {range} Extend from center: {extend}");
 
-            await motor.StartSpeedForDegreesAsync(extend, CW * 10, 10, SpecialSpeed.Hold, SpeedProfiles.None);
+            await motor.StartSpeedForDegreesAsync(extend, (sbyte)(CW * Speed), MaxPower, SpecialSpeed.Hold, SpeedProfiles.None);
 
             await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
             await motor.SetZeroAsync();

--- a/src/SharpBrick.PoweredUp/Functions/LinearMidCalibration.cs
+++ b/src/SharpBrick.PoweredUp/Functions/LinearMidCalibration.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using static SharpBrick.PoweredUp.Directions;
 
@@ -9,14 +8,14 @@ namespace SharpBrick.PoweredUp.Functions
 {
     public class LinearMidCalibration
     {
-        private IServiceProvider _serviceProvider;
+        private readonly ILogger<LinearMidCalibration> _logger;
 
         public byte MaxPower { get; set; } = 10;
         public byte Speed { get; set; } = 10;
 
-        public LinearMidCalibration(IServiceProvider serviceProvider)
+        public LinearMidCalibration(ILogger<LinearMidCalibration> logger)
         {
-            this._serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            this._logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public async Task ExecuteAsync(TachoMotor motor)
@@ -26,46 +25,44 @@ namespace SharpBrick.PoweredUp.Functions
                 throw new ArgumentNullException(nameof(motor));
             }
 
-            var logger = _serviceProvider.GetService<ILoggerFactory>().CreateLogger<LinearMidCalibration>();
-
-            logger.LogInformation("Start Linear Mid Calibration");
+            _logger.LogInformation("Start Linear Mid Calibration");
             await motor.TryLockDeviceForCombinedModeNotificationSetupAsync(motor.ModeIndexSpeed, motor.ModeIndexPosition);
             await motor.SetupNotificationAsync(motor.ModeIndexSpeed, true, 1);
             await motor.SetupNotificationAsync(motor.ModeIndexPosition, true, 1);
             await motor.UnlockFromCombinedModeNotificationSetupAsync(true);
 
-            logger.LogInformation("Start CW");
+            _logger.LogInformation("Start CW");
             await motor.StartPowerAsync((sbyte)(CW * MaxPower));
 
             await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
-            logger.LogInformation("Reached End by detecting no speed movement.");
+            _logger.LogInformation("Reached End by detecting no speed movement.");
 
             var cwVal = motor.Position;
-            logger.LogInformation($"CW End at {cwVal}.");
+            _logger.LogInformation($"CW End at {cwVal}.");
 
-            logger.LogInformation("Start CCW");
+            _logger.LogInformation("Start CCW");
             await motor.StartPowerAsync((sbyte)(CCW * MaxPower));
 
             await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
-            logger.LogInformation("Reached End by detecting no speed movement.");
+            _logger.LogInformation("Reached End by detecting no speed movement.");
 
             var ccwVal = motor.Position;
-            logger.LogInformation($"CW End at {ccwVal}.");
+            _logger.LogInformation($"CW End at {ccwVal}.");
 
             await motor.StopByBrakeAsync();
 
             var range = Math.Abs(cwVal - ccwVal);
             var extend = (uint)(range / 2);
-            logger.LogInformation($"Total Range: {range} Extend from center: {extend}");
+            _logger.LogInformation($"Total Range: {range} Extend from center: {extend}");
 
             await motor.StartSpeedForDegreesAsync(extend, (sbyte)(CW * Speed), MaxPower, SpecialSpeed.Hold, SpeedProfiles.None);
 
             await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
             await motor.SetZeroAsync();
-            logger.LogInformation($"Moved to center. Reset Position.");
+            _logger.LogInformation($"Moved to center. Reset Position.");
 
             await motor.UnlockFromCombinedModeNotificationSetupAsync(false);
-            logger.LogInformation($"End Linear Mid Calibration");
+            _logger.LogInformation($"End Linear Mid Calibration");
         }
     }
 }

--- a/src/SharpBrick.PoweredUp/Functions/LinearMidCalibration.cs
+++ b/src/SharpBrick.PoweredUp/Functions/LinearMidCalibration.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using static SharpBrick.PoweredUp.Directions;
+
+namespace SharpBrick.PoweredUp.Functions
+{
+    public class LinearMidCalibration
+    {
+        private IServiceProvider _serviceProvider;
+
+        public LinearMidCalibration(IServiceProvider serviceProvider)
+        {
+            this._serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+        }
+
+        public async Task ExecuteAsync(TachoMotor motor)
+        {
+            if (motor is null)
+            {
+                throw new ArgumentNullException(nameof(motor));
+            }
+
+            var logger = _serviceProvider.GetService<ILoggerFactory>().CreateLogger<LinearMidCalibration>();
+
+            logger.LogInformation("Start Linear Mid Calibration");
+            await motor.TryLockDeviceForCombinedModeNotificationSetupAsync(motor.ModeIndexSpeed, motor.ModeIndexPosition);
+            await motor.SetupNotificationAsync(motor.ModeIndexSpeed, true, 1);
+            await motor.SetupNotificationAsync(motor.ModeIndexPosition, true, 1);
+            await motor.UnlockFromCombinedModeNotificationSetupAsync(true);
+
+            logger.LogInformation("Start CW");
+            await motor.StartPowerAsync(CW * 10);
+
+            await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
+            logger.LogInformation("Reached End by detecting no speed movement.");
+
+            var cwVal = motor.Position;
+            logger.LogInformation($"CW End at {cwVal}.");
+
+            logger.LogInformation("Start CCW");
+            await motor.StartPowerAsync(CCW * 10);
+
+            await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
+            logger.LogInformation("Reached End by detecting no speed movement.");
+
+            var ccwVal = motor.Position;
+            logger.LogInformation($"CW End at {ccwVal}.");
+
+            await motor.StopByBrakeAsync();
+
+            var range = Math.Abs(cwVal - ccwVal);
+            var extend = (uint)(range / 2);
+            logger.LogInformation($"Total Range: {range} Extend from center: {extend}");
+
+            await motor.StartSpeedForDegreesAsync(extend, CW * 10, 10, SpecialSpeed.Hold, SpeedProfiles.None);
+
+            await motor.SpeedObservable.Where(x => x.SI == 0).FirstAsync().GetAwaiter();
+            await motor.SetZeroAsync();
+            logger.LogInformation($"Moved to center. Reset Position.");
+
+            await motor.UnlockFromCombinedModeNotificationSetupAsync(false);
+            logger.LogInformation($"End Linear Mid Calibration");
+        }
+    }
+}

--- a/src/SharpBrick.PoweredUp/Hubs/Hub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/Hub.cs
@@ -2,9 +2,7 @@ using System;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using SharpBrick.PoweredUp.Bluetooth;
 using SharpBrick.PoweredUp.Devices;
 using SharpBrick.PoweredUp.Protocol;
 using SharpBrick.PoweredUp.Protocol.Messages;
@@ -18,13 +16,12 @@ namespace SharpBrick.PoweredUp
         private readonly IDeviceFactory _deviceFactory;
 
         public IPoweredUpProtocol Protocol { get; private set; }
-        public byte HubId { get; }
+        public byte HubId { get; private set; }
         public IServiceProvider ServiceProvider { get; }
         public bool IsConnected => Protocol != null;
 
-        public Hub(byte hubId, IPoweredUpProtocol protocol, IDeviceFactory deviceFactory, ILogger<Hub> logger, IServiceProvider serviceProvider, Port[] knownPorts)
+        public Hub(IPoweredUpProtocol protocol, IDeviceFactory deviceFactory, ILogger<Hub> logger, IServiceProvider serviceProvider, Port[] knownPorts)
         {
-            HubId = hubId;
             Protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
             _deviceFactory = deviceFactory ?? throw new ArgumentNullException(nameof(deviceFactory));
             ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
@@ -35,6 +32,11 @@ namespace SharpBrick.PoweredUp
             SetupOnPortChangeObservable(Protocol.UpstreamMessages);
             SetupHubAlertObservable(Protocol.UpstreamMessages);
             SetupHubPropertyObservable(Protocol.UpstreamMessages);
+        }
+
+        public void Configure(byte hubId)
+        {
+            HubId = hubId;
         }
 
         #region Disposable Pattern

--- a/src/SharpBrick.PoweredUp/Hubs/HubFactory.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/HubFactory.cs
@@ -29,7 +29,7 @@ namespace SharpBrick.PoweredUp.Hubs
         }
 
         private Hub Create(Type type)
-            => _serviceProvider.GetService(type) as Hub ?? throw new NotSupportedException($"Hub with type {type} not registered in service locator supported.");
+            => _serviceProvider.GetService(type) as Hub ?? throw new NotSupportedException($"Hub with type {type} not registered in service locator supported."); // ServiceLocator ok: transient factory
 
         private SystemType GetSystemTypeFromManufacturerData(PoweredUpHubManufacturerData poweredUpHubManufacturerData)
             => (SystemType)poweredUpHubManufacturerData;

--- a/src/SharpBrick.PoweredUp/Hubs/Hub_Ports.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/Hub_Ports.cs
@@ -4,8 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
-using SharpBrick.PoweredUp.Devices;
 using SharpBrick.PoweredUp.Protocol;
 using SharpBrick.PoweredUp.Protocol.Messages;
 
@@ -114,9 +112,7 @@ namespace SharpBrick.PoweredUp
                 case HubAttachedIOForAttachedDeviceMessage attachedDeviceMessage:
                     port = Port(attachedDeviceMessage.PortId);
 
-                    var deviceFactory = ServiceProvider.GetService<IDeviceFactory>();
-
-                    var device = deviceFactory.CreateConnected(attachedDeviceMessage.IOTypeId, Protocol, attachedDeviceMessage.HubId, attachedDeviceMessage.PortId);
+                    var device = _deviceFactory.CreateConnected(attachedDeviceMessage.IOTypeId, Protocol, attachedDeviceMessage.HubId, attachedDeviceMessage.PortId);
 
                     port.AttachDevice(device, attachedDeviceMessage.IOTypeId);
                     break;
@@ -144,9 +140,7 @@ namespace SharpBrick.PoweredUp
 
             _ports[createdVirtualPort.PortId] = createdVirtualPort;
 
-            var deviceFactory = ServiceProvider.GetService<IDeviceFactory>();
-
-            var deviceOnVirtualPort = deviceFactory.CreateConnected(attachedVirtualDeviceMessage.IOTypeId, Protocol, attachedVirtualDeviceMessage.HubId, attachedVirtualDeviceMessage.PortId);
+            var deviceOnVirtualPort = _deviceFactory.CreateConnected(attachedVirtualDeviceMessage.IOTypeId, Protocol, attachedVirtualDeviceMessage.HubId, attachedVirtualDeviceMessage.PortId);
 
             createdVirtualPort.AttachDevice(deviceOnVirtualPort, attachedVirtualDeviceMessage.IOTypeId);
 

--- a/src/SharpBrick.PoweredUp/Hubs/IHubFactory.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/IHubFactory.cs
@@ -5,6 +5,6 @@ namespace SharpBrick.PoweredUp.Hubs
     public interface IHubFactory
     {
         Hub CreateByBluetoothManufacturerData(byte[] manufacturerData);
-        THub Create<THub>() where THub : class;
+        THub Create<THub>() where THub : Hub;
     }
 }

--- a/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
@@ -7,8 +7,8 @@ namespace SharpBrick.PoweredUp
 {
     public class TechnicMediumHub : Hub
     {
-        public TechnicMediumHub(byte hubId, IPoweredUpProtocol protocol, IDeviceFactory deviceFactory, ILogger<TechnicMediumHub> logger, IServiceProvider serviceProvider = default)
-            : base(hubId, protocol, deviceFactory, logger, serviceProvider, new Port[] {
+        public TechnicMediumHub(IPoweredUpProtocol protocol, IDeviceFactory deviceFactory, ILogger<TechnicMediumHub> logger, IServiceProvider serviceProvider = default)
+            : base(protocol, deviceFactory, logger, serviceProvider, new Port[] {
                 new Port(0, nameof(A), true),
                 new Port(1, nameof(B), true),
                 new Port(2, nameof(C), true),

--- a/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
@@ -1,11 +1,14 @@
 using System;
+using Microsoft.Extensions.Logging;
+using SharpBrick.PoweredUp.Devices;
+using SharpBrick.PoweredUp.Protocol;
 
 namespace SharpBrick.PoweredUp
 {
     public class TechnicMediumHub : Hub
     {
-        public TechnicMediumHub(byte hubId, IServiceProvider serviceProvider = default)
-            : base(hubId, serviceProvider, new Port[] {
+        public TechnicMediumHub(byte hubId, IPoweredUpProtocol protocol, IDeviceFactory deviceFactory, ILogger<TechnicMediumHub> logger, IServiceProvider serviceProvider = default)
+            : base(hubId, protocol, deviceFactory, logger, serviceProvider, new Port[] {
                 new Port(0, nameof(A), true),
                 new Port(1, nameof(B), true),
                 new Port(2, nameof(C), true),

--- a/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
+++ b/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
@@ -9,9 +9,9 @@ namespace SharpBrick.PoweredUp
     {
         public static IServiceCollection AddPoweredUp(this IServiceCollection self)
             => self
-                .AddSingleton<IHubFactory, HubFactory>()
-                .AddSingleton<IDeviceFactory, DeviceFactory>()
                 .AddSingleton<PoweredUpHost>()
+                .AddScoped<IHubFactory, HubFactory>()
+                .AddScoped<IDeviceFactory, DeviceFactory>()
                 .AddTransient<LinearMidCalibration>();
     }
 }

--- a/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
+++ b/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
@@ -1,7 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
+using SharpBrick.PoweredUp.Bluetooth;
 using SharpBrick.PoweredUp.Devices;
 using SharpBrick.PoweredUp.Functions;
 using SharpBrick.PoweredUp.Hubs;
+using SharpBrick.PoweredUp.Protocol;
 
 namespace SharpBrick.PoweredUp
 {
@@ -10,8 +12,10 @@ namespace SharpBrick.PoweredUp
         public static IServiceCollection AddPoweredUp(this IServiceCollection self)
             => self
                 .AddSingleton<PoweredUpHost>()
+                .AddScoped<BluetoothKernel>()
                 .AddScoped<IHubFactory, HubFactory>()
                 .AddScoped<IDeviceFactory, DeviceFactory>()
+                .AddScoped<IPoweredUpProtocol, PoweredUpProtocol>()
                 .AddTransient<LinearMidCalibration>();
     }
 }

--- a/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
+++ b/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
@@ -11,11 +11,19 @@ namespace SharpBrick.PoweredUp
     {
         public static IServiceCollection AddPoweredUp(this IServiceCollection self)
             => self
+                // global infrastructure
                 .AddSingleton<PoweredUpHost>()
+
+                // per connection infrastructure
                 .AddScoped<BluetoothKernel>()
                 .AddScoped<IHubFactory, HubFactory>()
                 .AddScoped<IDeviceFactory, DeviceFactory>()
                 .AddScoped<IPoweredUpProtocol, PoweredUpProtocol>()
+
+                // hubs
+                .AddTransient<TechnicMediumHub>()
+
+                // functions
                 .AddTransient<LinearMidCalibration>();
     }
 }

--- a/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
+++ b/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using SharpBrick.PoweredUp.Devices;
+using SharpBrick.PoweredUp.Functions;
 using SharpBrick.PoweredUp.Hubs;
 
 namespace SharpBrick.PoweredUp
@@ -10,6 +11,7 @@ namespace SharpBrick.PoweredUp
             => self
                 .AddSingleton<IHubFactory, HubFactory>()
                 .AddSingleton<IDeviceFactory, DeviceFactory>()
-                .AddSingleton<PoweredUpHost>();
+                .AddSingleton<PoweredUpHost>()
+                .AddTransient<LinearMidCalibration>();
     }
 }

--- a/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
+++ b/src/SharpBrick.PoweredUp/IServiceCollectionExtensions.cs
@@ -24,6 +24,8 @@ namespace SharpBrick.PoweredUp
                 .AddTransient<TechnicMediumHub>()
 
                 // functions
+                .AddTransient<DiscoverPorts>()
+                .AddTransient<TraceMessages>()
                 .AddTransient<LinearMidCalibration>();
     }
 }

--- a/src/SharpBrick.PoweredUp/PoweredUpHost.cs
+++ b/src/SharpBrick.PoweredUp/PoweredUpHost.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SharpBrick.PoweredUp.Bluetooth;
 using SharpBrick.PoweredUp.Hubs;
+using SharpBrick.PoweredUp.Protocol;
 
 namespace SharpBrick.PoweredUp
 {
@@ -99,6 +100,15 @@ namespace SharpBrick.PoweredUp
             }, hub));
 
             return hub;
+        }
+
+        public IPoweredUpProtocol CreateProtocol(ulong bluetoothAddress)
+        {
+            var serviceProvider = CreateBluetoothScope(bluetoothAddress);
+
+            var protocol = serviceProvider.GetService<IPoweredUpProtocol>();
+
+            return protocol;
         }
 
         private IServiceProvider CreateBluetoothScope(ulong bluetoothAddress)

--- a/src/SharpBrick.PoweredUp/PoweredUpHost.cs
+++ b/src/SharpBrick.PoweredUp/PoweredUpHost.cs
@@ -104,29 +104,30 @@ namespace SharpBrick.PoweredUp
 
         public IPoweredUpProtocol CreateProtocol(ulong bluetoothAddress)
         {
-            var serviceProvider = CreateBluetoothScope(bluetoothAddress);
+            var protocolScope = CreateProtocolScope(bluetoothAddress);
 
-            var protocol = serviceProvider.GetService<IPoweredUpProtocol>();
+            var protocol = protocolScope.ServiceProvider.GetService<IPoweredUpProtocol>();
 
             return protocol;
         }
 
-        private IServiceProvider CreateBluetoothScope(ulong bluetoothAddress)
+        public IServiceScope CreateProtocolScope(ulong bluetoothAddress)
         {
-            var scopedServiceProvider = ServiceProvider.CreateScope().ServiceProvider;
+            var scope = ServiceProvider.CreateScope();
+            var scopedServiceProvider = scope.ServiceProvider;
 
             // initialize scoped bluetooth kernel to bluetooth address.
             var kernel = scopedServiceProvider.GetService<BluetoothKernel>();
             kernel.BluetoothAddress = bluetoothAddress;
 
-            return scopedServiceProvider;
+            return scope;
         }
 
         private THub CreateHubInBluetoothScope<THub>(ulong bluetoothAddress, Func<IHubFactory, THub> factory) where THub : Hub
         {
-            var scopedServiceProvider = CreateBluetoothScope(bluetoothAddress);
+            var protocolScope = CreateProtocolScope(bluetoothAddress);
 
-            var hubFactory = scopedServiceProvider.GetService<IHubFactory>();
+            var hubFactory = protocolScope.ServiceProvider.GetService<IHubFactory>();
 
             var hub = factory(hubFactory);
 

--- a/src/SharpBrick.PoweredUp/Protocol/IPoweredUpProtocol.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/IPoweredUpProtocol.cs
@@ -15,5 +15,7 @@ namespace SharpBrick.PoweredUp.Protocol
         IObservable<(byte[] data, PoweredUpMessage message)> UpstreamRawMessages { get; }
 
         ProtocolKnowledge Knowledge { get; }
+
+        IServiceProvider ServiceProvider { get; }
     }
 }

--- a/src/SharpBrick.PoweredUp/Protocol/Knowledge/KnowledgeManager.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/Knowledge/KnowledgeManager.cs
@@ -104,7 +104,7 @@ namespace SharpBrick.PoweredUp.Protocol.Knowledge
 
             return applicableMessage;
         }
-        public static Task ApplyDynamicProtocolKnowledge(PoweredUpMessage message, ProtocolKnowledge knowledge, IServiceProvider serviceProvider)
+        public static Task ApplyDynamicProtocolKnowledge(PoweredUpMessage message, ProtocolKnowledge knowledge, IDeviceFactory deviceFactory)
         {
             HubInfo hub;
             PortInfo port;
@@ -125,7 +125,7 @@ namespace SharpBrick.PoweredUp.Protocol.Knowledge
                     port.HardwareRevision = msg.HardwareRevision;
                     port.SoftwareRevision = msg.SoftwareRevision;
 
-                    AddCachePortAndPortModeInformation(msg.IOTypeId, msg.HardwareRevision, msg.SoftwareRevision, port, knowledge, serviceProvider);
+                    AddCachePortAndPortModeInformation(msg.IOTypeId, msg.HardwareRevision, msg.SoftwareRevision, port, knowledge, deviceFactory);
                     break;
                 case HubAttachedIOForDetachedDeviceMessage msg:
                     port = knowledge.Port(msg.HubId, msg.PortId);
@@ -143,7 +143,7 @@ namespace SharpBrick.PoweredUp.Protocol.Knowledge
                     port.HardwareRevision = partOfVirtual.HardwareRevision;
                     port.SoftwareRevision = partOfVirtual.SoftwareRevision;
 
-                    AddCachePortAndPortModeInformation(msg.IOTypeId, partOfVirtual.HardwareRevision, partOfVirtual.SoftwareRevision, port, knowledge, serviceProvider);
+                    AddCachePortAndPortModeInformation(msg.IOTypeId, partOfVirtual.HardwareRevision, partOfVirtual.SoftwareRevision, port, knowledge, deviceFactory);
 
                     port.IsVirtual = true;
                     break;
@@ -176,9 +176,9 @@ namespace SharpBrick.PoweredUp.Protocol.Knowledge
             return Task.CompletedTask;
         }
 
-        private static void AddCachePortAndPortModeInformation(DeviceType type, Version hardwareRevision, Version softwareRevision, PortInfo port, ProtocolKnowledge knowledge, IServiceProvider serviceProvider)
+        private static void AddCachePortAndPortModeInformation(DeviceType type, Version hardwareRevision, Version softwareRevision, PortInfo port, ProtocolKnowledge knowledge, IDeviceFactory deviceFactory)
         {
-            var device = serviceProvider.GetService<IDeviceFactory>().Create(type);
+            var device = deviceFactory.Create(type);
 
             if (device != null)
             {

--- a/test/SharpBrick.PoweredUp.Test/Devices/VoltageTest.cs
+++ b/test/SharpBrick.PoweredUp.Test/Devices/VoltageTest.cs
@@ -73,14 +73,16 @@ namespace SharpBrick.PoweredUp
         {
             var serviceProvider = new ServiceCollection()
                 .AddLogging()
-                .AddSingleton<PoweredUpBluetoothAdapterMock>()
+                .AddSingleton<IPoweredUpBluetoothAdapter, PoweredUpBluetoothAdapterMock>()
+                .AddSingleton<BluetoothKernel>()
+                .AddSingleton<IPoweredUpProtocol, PoweredUpProtocol>()
                 .AddSingleton<IDeviceFactory, DeviceFactory>() // for protocol knowledge init
+
                 .BuildServiceProvider();
 
-            var poweredUpBluetoothAdapterMock = serviceProvider.GetService<PoweredUpBluetoothAdapterMock>();
+            var poweredUpBluetoothAdapterMock = serviceProvider.GetService<IPoweredUpBluetoothAdapter>() as PoweredUpBluetoothAdapterMock;
 
-            var kernel = ActivatorUtilities.CreateInstance<BluetoothKernel>(serviceProvider, (IPoweredUpBluetoothAdapter)poweredUpBluetoothAdapterMock, (ulong)0);
-            var protocol = ActivatorUtilities.CreateInstance<PoweredUpProtocol>(serviceProvider, kernel);
+            var protocol = serviceProvider.GetService<IPoweredUpProtocol>();
 
             protocol.ConnectAsync().Wait();
 

--- a/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueCombinedModeEncoderTest.cs
+++ b/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueCombinedModeEncoderTest.cs
@@ -21,7 +21,7 @@ namespace SharpBrick.PoweredUp.Protocol.Formatter
                 .AddPoweredUp()
                 .BuildServiceProvider();
 
-            KnowledgeManager.ApplyDynamicProtocolKnowledge(new HubAttachedIOForAttachedDeviceMessage() { HubId = 0, IOTypeId = DeviceType.TechnicLargeLinearMotor, MessageType = MessageType.HubAttachedIO, Event = HubAttachedIOEvent.AttachedIO, PortId = 0x00, HardwareRevision = new Version("0.0.0.1"), SoftwareRevision = new Version("0.0.0.1") }, knowledge, serviceProvider);
+            KnowledgeManager.ApplyDynamicProtocolKnowledge(new HubAttachedIOForAttachedDeviceMessage() { HubId = 0, IOTypeId = DeviceType.TechnicLargeLinearMotor, MessageType = MessageType.HubAttachedIO, Event = HubAttachedIOEvent.AttachedIO, PortId = 0x00, HardwareRevision = new Version("0.0.0.1"), SoftwareRevision = new Version("0.0.0.1") }, knowledge, serviceProvider.GetService<IDeviceFactory>());
             KnowledgeManager.ApplyDynamicProtocolKnowledge(new PortInputFormatSetupCombinedModeForSetModeDataSetMessage()
             {
                 PortId = 0,
@@ -32,7 +32,7 @@ namespace SharpBrick.PoweredUp.Protocol.Formatter
                         new PortInputFormatSetupCombinedModeModeDataSet() { Mode = 0x02, DataSet = 0, },
                         new PortInputFormatSetupCombinedModeModeDataSet() { Mode = 0x03, DataSet = 0, },
                     }
-            }, knowledge, serviceProvider);
+            }, knowledge, serviceProvider.GetService<IDeviceFactory>());
 
             // arrange
             var data = BytesStringUtil.StringToData(dataAsString);

--- a/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueEncoderTest.cs
+++ b/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueEncoderTest.cs
@@ -25,7 +25,7 @@ namespace SharpBrick.PoweredUp.Protocol.Formatter
                 .BuildServiceProvider();
 
 
-            KnowledgeManager.ApplyDynamicProtocolKnowledge(new HubAttachedIOForAttachedDeviceMessage() { HubId = 0, IOTypeId = DeviceType.TechnicMediumHubTiltSensor, MessageType = MessageType.HubAttachedIO, Event = HubAttachedIOEvent.AttachedIO, PortId = 0x63, HardwareRevision = new Version("0.0.0.1"), SoftwareRevision = new Version("0.0.0.1") }, knowledge, serviceProvider);
+            KnowledgeManager.ApplyDynamicProtocolKnowledge(new HubAttachedIOForAttachedDeviceMessage() { HubId = 0, IOTypeId = DeviceType.TechnicMediumHubTiltSensor, MessageType = MessageType.HubAttachedIO, Event = HubAttachedIOEvent.AttachedIO, PortId = 0x63, HardwareRevision = new Version("0.0.0.1"), SoftwareRevision = new Version("0.0.0.1") }, knowledge, serviceProvider.GetService<IDeviceFactory>());
 
             // arrange
             var data = BytesStringUtil.StringToData(dataAsString);


### PR DESCRIPTION
Cleanup IServiceProvider (as service locator usage)

- Remove many Service Locator usages
- Move HubFactory to be based on DI
- Move Protocol creation into DI and out of hub etc.
- Adjust CLI
- Fix await warnings

#46 non-breaking (all types internal)