### PR TITLE
Readme fix for dotnet install

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ DI Container Elements
 - Features
   - [X] Dynamic Device
   - [X] Deployment Verifier
-- Command Line (`dotnet install -g SharpBrick.PoweredUp.Cli`)
+- Command Line (`dotnet tool install -g SharpBrick.PoweredUp.Cli`)
   - [X] `poweredup device list` (discover all connected devices and their port (mode) properties)
   - [X] `poweredup device dump-static-port -p <port number>` (see [adding new devices tutorial](docs/development/adding-new-device.md))
 


### PR DESCRIPTION
During the scan process for new hubs/devices i struggled to install the cli because the command to install it was not complete. A small "tool" was missing in the command. This PR adds the missing part and makes it easier for future contributors. I decided to do a direct PR instead of opening an issue becaus it's such a small fix ;-) 