### PR TITLE
Add known SystemType to LegoWirelessProtocol

### DIFF
--- a/src/SharpBrick.PoweredUp/Devices/Current.cs
+++ b/src/SharpBrick.PoweredUp/Devices/Current.cs
@@ -34,7 +34,7 @@ namespace SharpBrick.PoweredUp
             ObserveForPropertyChanged(_currentSMode.Observable, nameof(CurrentS), nameof(CurrentSPct));
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-3B-01-02-02-03-00-00-00
 05-00-43-3B-02

--- a/src/SharpBrick.PoweredUp/Devices/DynamicDevice.cs
+++ b/src/SharpBrick.PoweredUp/Devices/DynamicDevice.cs
@@ -25,7 +25,7 @@ namespace SharpBrick.PoweredUp
             BuildModes();
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => Array.Empty<byte[]>();
     }
 }

--- a/src/SharpBrick.PoweredUp/Devices/IPoweredUpDevice.cs
+++ b/src/SharpBrick.PoweredUp/Devices/IPoweredUpDevice.cs
@@ -6,6 +6,6 @@ namespace SharpBrick.PoweredUp
     public interface IPoweredUpDevice
     {
         bool IsConnected { get; }
-        IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion);
+        IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType);
     }
 }

--- a/src/SharpBrick.PoweredUp/Devices/RgbLight.cs
+++ b/src/SharpBrick.PoweredUp/Devices/RgbLight.cs
@@ -70,7 +70,7 @@ namespace SharpBrick.PoweredUp
             return response;
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-32-01-01-02-00-00-03-00
 05-00-43-32-02

--- a/src/SharpBrick.PoweredUp/Devices/TechnicLargeLinearMotor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicLargeLinearMotor.cs
@@ -15,7 +15,7 @@ namespace SharpBrick.PoweredUp
             : base(protocol, hubId, portId)
         { }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-00-01-0F-06-1E-00-1F-00
 07-00-43-00-02-0E-00

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubAccelerometer.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubAccelerometer.cs
@@ -29,7 +29,7 @@ namespace SharpBrick.PoweredUp
             ObserveForPropertyChanged(_gravityMode.Observable, nameof(Gravity));
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-61-01-02-02-03-00-00-00
 05-00-43-61-02

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGestSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGestSensor.cs
@@ -28,7 +28,7 @@ namespace SharpBrick.PoweredUp
             ObserveForPropertyChanged(_gestureMode.Observable, nameof(Gesture));
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-64-01-02-01-01-00-00-00
 05-00-43-64-02

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGyroSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGyroSensor.cs
@@ -27,7 +27,7 @@ namespace SharpBrick.PoweredUp
             ObserveForPropertyChanged(_rotationMode.Observable, nameof(Rotation));
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-62-01-02-01-01-00-00-00
 05-00-43-62-02

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTemperatureSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTemperatureSensor.cs
@@ -26,7 +26,7 @@ namespace SharpBrick.PoweredUp
             ObserveForPropertyChanged(_temperatureMode.Observable, nameof(Temperature), nameof(TemperaturePct));
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-60-01-02-01-01-00-00-00
 05-00-43-60-02

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTiltSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTiltSensor.cs
@@ -120,7 +120,7 @@ namespace SharpBrick.PoweredUp
             return response;
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => (softwareVersion.ToString(), hardwareVersion.ToString()) switch
             {
                 ("0.0.0.1", "0.0.0.1") =>

--- a/src/SharpBrick.PoweredUp/Devices/TechnicXLargeLinearMotor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicXLargeLinearMotor.cs
@@ -16,7 +16,7 @@ namespace SharpBrick.PoweredUp
             : base(protocol, hubId, portId)
         { }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
             => @"
 0B-00-43-02-01-0F-06-1E-00-1F-00
 07-00-43-02-02-0E-00

--- a/src/SharpBrick.PoweredUp/Devices/Voltage.cs
+++ b/src/SharpBrick.PoweredUp/Devices/Voltage.cs
@@ -34,8 +34,10 @@ namespace SharpBrick.PoweredUp
             ObserveForPropertyChanged(_voltageSMode.Observable, nameof(VoltageS), nameof(VoltageSPct));
         }
 
-        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion)
-            => @"
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
+            => ((softwareVersion, hardwareVersion, systemType) switch
+            {
+                (_, _, SystemType.LegoTechnic_MediumHub) => @"
 0B-00-43-3C-01-02-02-03-00-00-00
 05-00-43-3C-02
 11-00-44-3C-00-00-56-4C-54-20-4C-00-00-00-00-00-00
@@ -52,6 +54,8 @@ namespace SharpBrick.PoweredUp
 0A-00-44-3C-01-04-6D-56-00-00
 08-00-44-3C-01-05-10-00
 0A-00-44-3C-01-80-01-01-04-00
-".Trim().Split("\n").Select(s => BytesStringUtil.StringToData(s));
+",
+                _ => throw new NotImplementedException(),
+            }).Trim().Split("\n").Select(s => BytesStringUtil.StringToData(s));
     }
 }

--- a/src/SharpBrick.PoweredUp/Hubs/Hub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/Hub.cs
@@ -14,17 +14,19 @@ namespace SharpBrick.PoweredUp
         private CompositeDisposable _compositeDisposable = new CompositeDisposable();
         private readonly ILogger _logger;
         private readonly IDeviceFactory _deviceFactory;
+        private readonly SystemType _knownSystemType;
 
         public ILegoWirelessProtocol Protocol { get; private set; }
         public byte HubId { get; private set; }
         public IServiceProvider ServiceProvider { get; }
         public bool IsConnected => Protocol != null;
 
-        public Hub(ILegoWirelessProtocol protocol, IDeviceFactory deviceFactory, ILogger<Hub> logger, IServiceProvider serviceProvider, Port[] knownPorts)
+        public Hub(ILegoWirelessProtocol protocol, IDeviceFactory deviceFactory, ILogger<Hub> logger, IServiceProvider serviceProvider, SystemType knownSystemType, Port[] knownPorts)
         {
             Protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
             _deviceFactory = deviceFactory ?? throw new ArgumentNullException(nameof(deviceFactory));
             ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
+            _knownSystemType = knownSystemType;
             AddKnownPorts(knownPorts ?? throw new ArgumentNullException(nameof(knownPorts)));
             _logger = logger;
 
@@ -59,7 +61,7 @@ namespace SharpBrick.PoweredUp
             var expectedDevicesCompletedTask = ExpectedDevicesCompletedAsync();
 
             _logger?.LogDebug("Connecting BluetoothKernel");
-            await Protocol.ConnectAsync();
+            await Protocol.ConnectAsync(_knownSystemType);
 
             await expectedDevicesCompletedTask;
             _logger?.LogDebug("Hub Attached IO expected devices completed");

--- a/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
@@ -8,7 +8,7 @@ namespace SharpBrick.PoweredUp
     public class TechnicMediumHub : Hub
     {
         public TechnicMediumHub(ILegoWirelessProtocol protocol, IDeviceFactory deviceFactory, ILogger<TechnicMediumHub> logger, IServiceProvider serviceProvider = default)
-            : base(protocol, deviceFactory, logger, serviceProvider, new Port[] {
+            : base(protocol, deviceFactory, logger, serviceProvider, SystemType.LegoTechnic_MediumHub, new Port[] {
                 new Port(0, nameof(A), true),
                 new Port(1, nameof(B), true),
                 new Port(2, nameof(C), true),

--- a/src/SharpBrick.PoweredUp/Protocol/ILegoWirelessProtocol.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/ILegoWirelessProtocol.cs
@@ -7,7 +7,7 @@ namespace SharpBrick.PoweredUp.Protocol
 {
     public interface ILegoWirelessProtocol : IDisposable
     {
-        Task ConnectAsync();
+        Task ConnectAsync(SystemType initialSystemType = default);
         Task DisconnectAsync();
 
         Task SendMessageAsync(LegoWirelessMessage message);

--- a/src/SharpBrick.PoweredUp/Protocol/LegoWirelessProtocol.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/LegoWirelessProtocol.cs
@@ -33,8 +33,17 @@ namespace SharpBrick.PoweredUp.Protocol
             _upstreamSubject = new Subject<(byte[] data, LegoWirelessMessage message)>();
         }
 
-        public async Task ConnectAsync()
+        public async Task ConnectAsync(SystemType knownSystemType = default)
         {
+            // sets initial system type to provided value. This alllows sensitive IPoweredUpDevice to provide the right GetStaticPortInfo (even on initial HubAttachedIO before a HubProperty<SystemType> can be queried).
+            await KnowledgeManager.ApplyDynamicProtocolKnowledge(new HubPropertyMessage<SystemType>()
+            {
+                HubId = 0x00,
+                Operation = HubPropertyOperation.Update,
+                Property = HubProperty.SystemTypeId,
+                Payload = knownSystemType,
+            }, Knowledge, _deviceFactory);
+
             await _kernel.ConnectAsync();
 
             await _kernel.ReceiveBytesAsync(async data =>

--- a/test/SharpBrick.PoweredUp.Test/Devices/VoltageTest.cs
+++ b/test/SharpBrick.PoweredUp.Test/Devices/VoltageTest.cs
@@ -15,7 +15,7 @@ namespace SharpBrick.PoweredUp
         public async Task Voltage_VoltageLObservable_Receive()
         {
             // arrange
-            var (protocol, mock) = CreateProtocolAndMock();
+            var (protocol, mock) = CreateProtocolAndMock(SystemType.LegoTechnic_MediumHub);
 
             // announce voltage device in protocol
             await mock.WriteUpstreamAsync(new HubAttachedIOForAttachedDeviceMessage()
@@ -69,7 +69,7 @@ namespace SharpBrick.PoweredUp
         }
 
 
-        internal (ILegoWirelessProtocol protocol, PoweredUpBluetoothCharacteristicMock mock) CreateProtocolAndMock()
+        internal (ILegoWirelessProtocol protocol, PoweredUpBluetoothCharacteristicMock mock) CreateProtocolAndMock(SystemType knownSystemType)
         {
             var serviceProvider = new ServiceCollection()
                 .AddLogging()
@@ -84,7 +84,7 @@ namespace SharpBrick.PoweredUp
 
             var protocol = serviceProvider.GetService<ILegoWirelessProtocol>();
 
-            protocol.ConnectAsync().Wait();
+            protocol.ConnectAsync(knownSystemType).Wait();
 
             return (protocol, poweredUpBluetoothAdapterMock.MockCharacteristic);
         }


### PR DESCRIPTION
- Known SystemType allows the protocol to react to HubAttachedIO w/
  the right static port data specified for a given device.
- Adjusted existing IPoweredUpDevice

Closes #98 non-breaking (internal API, default values)