### PR TITLE
Bluetooth api changes

### DIFF
--- a/src/SharpBrick.PoweredUp.Cli/Program.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Program.cs
@@ -146,6 +146,9 @@ namespace SharpBrick.PoweredUp.Cli
 
                     idx++;
                 }
+
+                return Task.CompletedTask;
+
             }, cts.Token);
 
             var input = Console.ReadLine();

--- a/src/SharpBrick.PoweredUp.WinRT/WinRTPoweredUpBluetoothAdapter.cs
+++ b/src/SharpBrick.PoweredUp.WinRT/WinRTPoweredUpBluetoothAdapter.cs
@@ -10,7 +10,7 @@ namespace SharpBrick.PoweredUp.WinRT
 {
     public class WinRTPoweredUpBluetoothAdapter : IPoweredUpBluetoothAdapter
     {
-        public void Discover(Action<PoweredUpBluetoothDeviceInfo> discoveryHandler, CancellationToken cancellationToken = default)
+        public void Discover(Func<PoweredUpBluetoothDeviceInfo, Task> discoveryHandler, CancellationToken cancellationToken = default)
         {
             BluetoothLEAdvertisementWatcher watcher = new BluetoothLEAdvertisementWatcher();
             watcher.ScanningMode = BluetoothLEScanningMode.Active;
@@ -26,7 +26,7 @@ namespace SharpBrick.PoweredUp.WinRT
 
             watcher.Start();
 
-            void ReceivedHandler(BluetoothLEAdvertisementWatcher watcher, BluetoothLEAdvertisementReceivedEventArgs eventArgs)
+            async void ReceivedHandler(BluetoothLEAdvertisementWatcher watcher, BluetoothLEAdvertisementReceivedEventArgs eventArgs)
             {
                 var info = new PoweredUpBluetoothDeviceInfo();
 
@@ -47,7 +47,7 @@ namespace SharpBrick.PoweredUp.WinRT
 
                 info.BluetoothAddress = eventArgs.BluetoothAddress;
 
-                discoveryHandler(info);
+                await discoveryHandler(info);
             }
         }
 

--- a/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothAdapter.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothAdapter.cs
@@ -6,7 +6,7 @@ namespace SharpBrick.PoweredUp.Bluetooth
 {
     public interface IPoweredUpBluetoothAdapter
     {
-        void Discover(Action<PoweredUpBluetoothDeviceInfo> discoveryHandler, CancellationToken cancellationToken = default);
+        void Discover(Func<PoweredUpBluetoothDeviceInfo, Task> discoveryHandler, CancellationToken cancellationToken = default);
 
         Task<IPoweredUpBluetoothDevice> GetDeviceAsync(ulong bluetoothAddress);
     }

--- a/src/SharpBrick.PoweredUp/PoweredUpHost.cs
+++ b/src/SharpBrick.PoweredUp/PoweredUpHost.cs
@@ -43,7 +43,7 @@ namespace SharpBrick.PoweredUp
 
         public void Discover(Func<Hub, Task> onDiscovery, CancellationToken token = default)
         {
-            _bluetoothAdapter.Discover(deviceInfo =>
+            _bluetoothAdapter.Discover(async deviceInfo =>
             {
                 try
                 {
@@ -55,7 +55,7 @@ namespace SharpBrick.PoweredUp
 
                         _logger.LogInformation($"Discovered log of type {hub.GetType().Name} with name '{deviceInfo.Name}' on Bluetooth Address '{deviceInfo.BluetoothAddress}'");
 
-                        onDiscovery(hub).Wait();
+                        await onDiscovery(hub);
                     }
                 }
                 catch (Exception e)

--- a/test/SharpBrick.PoweredUp.Test/Bluetooth/PoweredUpBluetoothAdapterMock.cs
+++ b/test/SharpBrick.PoweredUp.Test/Bluetooth/PoweredUpBluetoothAdapterMock.cs
@@ -23,7 +23,7 @@ namespace SharpBrick.PoweredUp
         public PoweredUpBluetoothServiceMock MockService { get; }
         public PoweredUpBluetoothCharacteristicMock MockCharacteristic { get; }
 
-        public void Discover(Action<PoweredUpBluetoothDeviceInfo> discoveryHandler, CancellationToken cancellationToken = default)
+        public void Discover(Func<PoweredUpBluetoothDeviceInfo, Task> discoveryHandler, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
This would be the _minimal_ changes I need to be able to integrate bluez support properly and avoid deadlocks.

---- 

There's something else I'd like to propose, since the library targets .net standard 2.1 (and thus C# 8 is standard) maybe it's nice to leverage IAsyncEnumerable for the Discover method, so it becomes something like:

`IAsyncEnumerable<PoweredUpBluetoothDeviceInfo> Discover(CancellationToken cancellationToken = default)`

This way the newly discovered devices would be streamed to whoever is invoking the discovery as they become available.

---- 

And about the BluetoothAdapter class, is this meant to be a representation of an actual bluetooth adapter, or is it more like an bluetooth managing class? Since at least on linux (and I assume on windows too), you can have multiple adapters and I guess it would be nice to have some interface to list and select the adapter you want (and provide some convenience methods to simply select the first one available)

Closes #117 