### PR TITLE
Add known HubProperties

### DIFF
--- a/src/SharpBrick.PoweredUp/Hubs/Hub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/Hub.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace SharpBrick.PoweredUp
         public IServiceProvider ServiceProvider { get; }
         public bool IsConnected => Protocol != null;
 
-        public Hub(ILegoWirelessProtocol protocol, IDeviceFactory deviceFactory, ILogger<Hub> logger, IServiceProvider serviceProvider, SystemType knownSystemType, Port[] knownPorts)
+        public Hub(ILegoWirelessProtocol protocol, IDeviceFactory deviceFactory, ILogger<Hub> logger, IServiceProvider serviceProvider, SystemType knownSystemType, Port[] knownPorts, IEnumerable<HubProperty> knownProperties = default)
         {
             Protocol = protocol ?? throw new ArgumentNullException(nameof(protocol));
             _deviceFactory = deviceFactory ?? throw new ArgumentNullException(nameof(deviceFactory));
@@ -30,6 +31,7 @@ namespace SharpBrick.PoweredUp
             AddKnownPorts(knownPorts ?? throw new ArgumentNullException(nameof(knownPorts)));
             _logger = logger;
 
+            SetupHubProperties(knownProperties);
             SetupOnHubChange();
             SetupOnPortChangeObservable(Protocol.UpstreamMessages);
             SetupHubAlertObservable(Protocol.UpstreamMessages);

--- a/src/SharpBrick.PoweredUp/Hubs/Hub_Properties.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/Hub_Properties.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using SharpBrick.PoweredUp.Protocol;
@@ -42,6 +44,29 @@ namespace SharpBrick.PoweredUp
         public IObservable<sbyte> RssiObservable { get; private set; }
         public IObservable<byte> BatteryVoltageInPercentObservable { get; private set; }
 
+        private IEnumerable<HubProperty> _knownProperties;
+
+        private void SetupHubProperties(IEnumerable<HubProperty> knownProperties)
+        {
+            _knownProperties = knownProperties ?? new HubProperty[] {
+                HubProperty.AdvertisingName,
+                HubProperty.Button,
+                HubProperty.FwVersion,
+                HubProperty.HwVersion,
+                HubProperty.Rssi,
+                HubProperty.BatteryVoltage,
+                HubProperty.BatteryType,
+                HubProperty.ManufacturerName,
+                HubProperty.RadioFirmwareVersion,
+                HubProperty.LegoWirelessProtocolVersion,
+                HubProperty.SystemTypeId,
+                HubProperty.HardwareNetworkId,
+                HubProperty.PrimaryMacAddress,
+                HubProperty.SecondaryMacAddress,
+                HubProperty.HardwareNetworkFamily,
+            };
+        }
+
         private void SetupHubPropertyObservable(IObservable<LegoWirelessMessage> upstreamMessages)
         {
             PropertyChangedObservable = upstreamMessages
@@ -64,23 +89,7 @@ namespace SharpBrick.PoweredUp
 
         private async Task InitialHubPropertiesQueryAsync()
         {
-            await Task.WhenAll(
-                RequestHubPropertySingleUpdate(HubProperty.AdvertisingName),
-                RequestHubPropertySingleUpdate(HubProperty.Button),
-                RequestHubPropertySingleUpdate(HubProperty.FwVersion),
-                RequestHubPropertySingleUpdate(HubProperty.HwVersion),
-                RequestHubPropertySingleUpdate(HubProperty.Rssi),
-                RequestHubPropertySingleUpdate(HubProperty.BatteryVoltage),
-                RequestHubPropertySingleUpdate(HubProperty.BatteryType),
-                RequestHubPropertySingleUpdate(HubProperty.ManufacturerName),
-                RequestHubPropertySingleUpdate(HubProperty.RadioFirmwareVersion),
-                RequestHubPropertySingleUpdate(HubProperty.LegoWirelessProtocolVersion),
-                RequestHubPropertySingleUpdate(HubProperty.SystemTypeId),
-                RequestHubPropertySingleUpdate(HubProperty.HardwareNetworkId),
-                RequestHubPropertySingleUpdate(HubProperty.PrimaryMacAddress),
-                RequestHubPropertySingleUpdate(HubProperty.SecondaryMacAddress)
-            // RequestHubPropertySingleUpdate(HubProperty.HardwareNetworkFamily) does not work .. at least for TechnicMediumHub. Throws command not recognized error.
-            );
+            await Task.WhenAll(_knownProperties.Select(property => RequestHubPropertySingleUpdate(property)));
         }
 
         public Task RequestHubPropertySingleUpdate(HubProperty property)

--- a/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/TechnicMediumHub.cs
@@ -22,6 +22,23 @@ namespace SharpBrick.PoweredUp
                 new Port(98, string.Empty, false, expectedDevice: DeviceType.TechnicMediumHubGyroSensor),
                 new Port(99, string.Empty, false, expectedDevice: DeviceType.TechnicMediumHubTiltSensor),
                 new Port(100, string.Empty, false, expectedDevice: DeviceType.TechnicMediumHubGestureSensor),
+            },
+            knownProperties: new HubProperty[] {
+                HubProperty.AdvertisingName,
+                HubProperty.Button,
+                HubProperty.FwVersion,
+                HubProperty.HwVersion,
+                HubProperty.Rssi,
+                HubProperty.BatteryVoltage,
+                HubProperty.BatteryType,
+                HubProperty.ManufacturerName,
+                HubProperty.RadioFirmwareVersion,
+                HubProperty.LegoWirelessProtocolVersion,
+                HubProperty.SystemTypeId,
+                HubProperty.HardwareNetworkId,
+                HubProperty.PrimaryMacAddress,
+                HubProperty.SecondaryMacAddress,
+                //HubProperty.HardwareNetworkFamily, //  Throws command not recognized error for TechnicMediumHub
             })
         { }
 

--- a/src/SharpBrick.PoweredUp/Hubs/TwoPortHub.cs
+++ b/src/SharpBrick.PoweredUp/Hubs/TwoPortHub.cs
@@ -14,6 +14,23 @@ namespace SharpBrick.PoweredUp
                 new Port(50, string.Empty, false, expectedDevice: DeviceType.RgbLight),
                 new Port(59, string.Empty, false, expectedDevice: DeviceType.Current),
                 new Port(60, string.Empty, false, expectedDevice: DeviceType.Voltage),
+            },
+            knownProperties: new HubProperty[] {
+                HubProperty.AdvertisingName,
+                HubProperty.Button,
+                HubProperty.FwVersion,
+                HubProperty.HwVersion,
+                HubProperty.Rssi,
+                HubProperty.BatteryVoltage,
+                HubProperty.BatteryType,
+                HubProperty.ManufacturerName,
+                HubProperty.RadioFirmwareVersion,
+                HubProperty.LegoWirelessProtocolVersion,
+                HubProperty.SystemTypeId,
+                HubProperty.HardwareNetworkId,
+                HubProperty.PrimaryMacAddress,
+                HubProperty.SecondaryMacAddress,
+                //HubProperty.HardwareNetworkFamily, // support status unknown for TwoPortHub
             })
         { }
 


### PR DESCRIPTION
- Add Hub constructor argument (is filled automatically if not set)
- Query hub properties by known properties instead of static array
- Adjusted TechnicMediumHub and TwoPortHub

Closes #120 non-breaking