### PR TITLE
Add Option to decode SI/PCT to Double instead of using Raw DataType

### DIFF
--- a/examples/SharpBrick.PoweredUp.Examples/ExampleDynamicDevice.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleDynamicDevice.cs
@@ -54,9 +54,9 @@ namespace Example
             await dynamicDeviceWhichIsAMotor.UnlockFromCombinedModeNotificationSetupAsync(true);
 
             // get the individual modes for input and output
-            var powerMode = dynamicDeviceWhichIsAMotor.SingleValueMode<sbyte>(0);
-            var posMode = dynamicDeviceWhichIsAMotor.SingleValueMode<int>(2);
-            var aposMode = dynamicDeviceWhichIsAMotor.SingleValueMode<short>(3);
+            var powerMode = dynamicDeviceWhichIsAMotor.SingleValueMode<sbyte, sbyte>(0);
+            var posMode = dynamicDeviceWhichIsAMotor.SingleValueMode<int, int>(2);
+            var aposMode = dynamicDeviceWhichIsAMotor.SingleValueMode<short, short>(3);
 
             // use their observables to report values
             using var disposable = posMode.Observable.Subscribe(x => Log.LogWarning($"Position: {x.SI} / {x.Pct}"));

--- a/src/SharpBrick.PoweredUp/Devices/AbsoluteMotor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/AbsoluteMotor.cs
@@ -8,12 +8,12 @@ namespace SharpBrick.PoweredUp
 {
     public abstract class AbsoluteMotor : TachoMotor
     {
-        protected SingleValueMode<short> _absoluteMode;
+        protected SingleValueMode<short, short> _absoluteMode;
         public byte ModeIndexAbsolutePosition { get; protected set; } = 3;
 
         public short AbsolutePosition => _absoluteMode.SI;
         public short AbsolutePositionPct => _absoluteMode.Pct;
-        public IObservable<Value<short>> AbsolutePositionObservable => _absoluteMode.Observable;
+        public IObservable<Value<short, short>> AbsolutePositionObservable => _absoluteMode.Observable;
 
         public AbsoluteMotor()
         { }
@@ -21,7 +21,7 @@ namespace SharpBrick.PoweredUp
         protected AbsoluteMotor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _absoluteMode = SingleValueMode<short>(ModeIndexAbsolutePosition);
+            _absoluteMode = SingleValueMode<short, short>(ModeIndexAbsolutePosition);
 
             ObserveForPropertyChanged(_absoluteMode.Observable, nameof(AbsolutePosition), nameof(AbsolutePositionPct));
         }

--- a/src/SharpBrick.PoweredUp/Devices/BasicMotor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/BasicMotor.cs
@@ -7,12 +7,12 @@ namespace SharpBrick.PoweredUp
 {
     public abstract class BasicMotor : Device
     {
-        protected SingleValueMode<sbyte> _powerMode;
+        protected SingleValueMode<sbyte, sbyte> _powerMode;
         public byte ModeIndexPower { get; protected set; } = 0;
 
         public sbyte Power => _powerMode.SI;
         public sbyte PowerPct => _powerMode.Pct;
-        public IObservable<Value<sbyte>> PowerObservable => _powerMode.Observable;
+        public IObservable<Value<sbyte, sbyte>> PowerObservable => _powerMode.Observable;
 
         public BasicMotor()
         { }
@@ -20,7 +20,7 @@ namespace SharpBrick.PoweredUp
         public BasicMotor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _powerMode = SingleValueMode<sbyte>(ModeIndexPower);
+            _powerMode = SingleValueMode<sbyte, sbyte>(ModeIndexPower);
 
             ObserveForPropertyChanged(_powerMode.Observable, nameof(Power), nameof(PowerPct));
         }

--- a/src/SharpBrick.PoweredUp/Devices/ColorDistanceSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/ColorDistanceSensor.cs
@@ -9,62 +9,62 @@ using System.Threading.Tasks;
 
 namespace SharpBrick.PoweredUp
 {
-	public class ColorDistanceSensor : Device, IPoweredUpDevice
-	{
-		protected SingleValueMode<sbyte> _colorMode;
-		protected SingleValueMode<sbyte> _proximityMode;
-		protected SingleValueMode<int> _countMode;
-		protected SingleValueMode<sbyte> _reflectionMode;
-		protected SingleValueMode<sbyte> _ambientLightMode;
-		protected SingleValueMode<sbyte> _lightMode;
-		protected MultiValueMode<short> _rgbMode;
+    public class ColorDistanceSensor : Device, IPoweredUpDevice
+    {
+        protected SingleValueMode<sbyte, sbyte> _colorMode;
+        protected SingleValueMode<sbyte, sbyte> _proximityMode;
+        protected SingleValueMode<int, int> _countMode;
+        protected SingleValueMode<sbyte, sbyte> _reflectionMode;
+        protected SingleValueMode<sbyte, sbyte> _ambientLightMode;
+        protected SingleValueMode<sbyte, sbyte> _lightMode;
+        protected MultiValueMode<short, short> _rgbMode;
 
-		public byte ModeIndexColor { get; protected set; } = 0;
-		public byte ModeIndexProximity { get; protected set; } = 1;
-		public byte ModeIndexCount { get; protected set; } = 2;
-		public byte ModeIndexReflection { get; protected set; } = 3;
-		public byte ModeIndexAmbientLight { get; protected set; } = 4;
-		public byte ModeIndexLight { get; protected set; } = 5;
-		public byte ModeIndexRgb { get; protected set; } = 6;
-		public byte ModeIndexIRTx { get; protected set; } = 7;
-		public byte ModeIndexSPEC1 { get; protected set; } = 8;
-		public byte ModeIndexDebug { get; protected set; } = 9;
-		public byte ModeIndexCalibration { get; protected set; } = 10;
+        public byte ModeIndexColor { get; protected set; } = 0;
+        public byte ModeIndexProximity { get; protected set; } = 1;
+        public byte ModeIndexCount { get; protected set; } = 2;
+        public byte ModeIndexReflection { get; protected set; } = 3;
+        public byte ModeIndexAmbientLight { get; protected set; } = 4;
+        public byte ModeIndexLight { get; protected set; } = 5;
+        public byte ModeIndexRgb { get; protected set; } = 6;
+        public byte ModeIndexIRTx { get; protected set; } = 7;
+        public byte ModeIndexSPEC1 { get; protected set; } = 8;
+        public byte ModeIndexDebug { get; protected set; } = 9;
+        public byte ModeIndexCalibration { get; protected set; } = 10;
 
-		public TechnicColor Color => (TechnicColor)_colorMode.SI;
-		public IObservable<TechnicColor> ColorObservable => _colorMode.Observable.Select(v => (TechnicColor)v.SI);
-		public IObservable<sbyte> ProximityObservable => _proximityMode.Observable.Select(v => v.SI);
-		public IObservable<int> CountObservable => _countMode.Observable.Select(v => v.SI);
-		public IObservable<sbyte> ReflectionObservable => _reflectionMode.Observable.Select(v => v.SI);
-		public IObservable<sbyte> AmbientLightObservable => _ambientLightMode.Observable.Select(v => v.SI);
-		public IObservable<(short red, short green, short blue)> RgbObservable => _rgbMode.Observable.Select(v => (v.SI[0], v.SI[1], v.SI[2]));
+        public TechnicColor Color => (TechnicColor)_colorMode.SI;
+        public IObservable<TechnicColor> ColorObservable => _colorMode.Observable.Select(v => (TechnicColor)v.SI);
+        public IObservable<sbyte> ProximityObservable => _proximityMode.Observable.Select(v => v.SI);
+        public IObservable<int> CountObservable => _countMode.Observable.Select(v => v.SI);
+        public IObservable<sbyte> ReflectionObservable => _reflectionMode.Observable.Select(v => v.SI);
+        public IObservable<sbyte> AmbientLightObservable => _ambientLightMode.Observable.Select(v => v.SI);
+        public IObservable<(short red, short green, short blue)> RgbObservable => _rgbMode.Observable.Select(v => (v.SI[0], v.SI[1], v.SI[2]));
 
-		public ColorDistanceSensor()
-		{ }
-		public ColorDistanceSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
-			: base(protocol, hubId, portId)
-		{
-			_colorMode = SingleValueMode<sbyte>(ModeIndexColor);
-			_proximityMode = SingleValueMode<sbyte>(ModeIndexProximity);
-			_countMode = SingleValueMode<int>(ModeIndexCount);
-			_reflectionMode = SingleValueMode<sbyte>(ModeIndexReflection);
-			_ambientLightMode = SingleValueMode<sbyte>(ModeIndexAmbientLight);
-			_lightMode = SingleValueMode<sbyte>(ModeIndexLight);
-			_rgbMode = MultiValueMode<short>(ModeIndexRgb);
-		}
+        public ColorDistanceSensor()
+        { }
+        public ColorDistanceSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
+            : base(protocol, hubId, portId)
+        {
+            _colorMode = SingleValueMode<sbyte, sbyte>(ModeIndexColor);
+            _proximityMode = SingleValueMode<sbyte, sbyte>(ModeIndexProximity);
+            _countMode = SingleValueMode<int, int>(ModeIndexCount);
+            _reflectionMode = SingleValueMode<sbyte, sbyte>(ModeIndexReflection);
+            _ambientLightMode = SingleValueMode<sbyte, sbyte>(ModeIndexAmbientLight);
+            _lightMode = SingleValueMode<sbyte, sbyte>(ModeIndexLight);
+            _rgbMode = MultiValueMode<short, short>(ModeIndexRgb);
+        }
 
-		protected override uint GetDefaultDeltaInterval(byte modeIndex)
-		   => modeIndex switch
-		   {
-			   0 => 1,
-			   2 => 1,
-			   _ => base.GetDefaultDeltaInterval(modeIndex),
-		   };
+        protected override uint GetDefaultDeltaInterval(byte modeIndex)
+           => modeIndex switch
+           {
+               0 => 1,
+               2 => 1,
+               _ => base.GetDefaultDeltaInterval(modeIndex),
+           };
 
-		public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
-			=> ((softwareVersion, hardwareVersion, systemType) switch
-				{
-					(_, _, _) => @"
+        public IEnumerable<byte[]> GetStaticPortInfoMessages(Version softwareVersion, Version hardwareVersion, SystemType systemType)
+            => ((softwareVersion, hardwareVersion, systemType) switch
+            {
+                (_, _, _) => @"
 0B-00-43-01-01-07-0B-5F-06-A0-00
 07-00-43-01-02-4F-00
 12-00-44-01-00-00-43-4F-4C-4F-52-00-00-00-00-00-00-00
@@ -145,6 +145,6 @@ namespace SharpBrick.PoweredUp
 08-00-44-01-0A-05-10-00
 0A-00-44-01-0A-80-08-01-05-00
 "
-				}).Trim().Split("\n").Select(s => BytesStringUtil.StringToData(s));
-	}
+            }).Trim().Split("\n").Select(s => BytesStringUtil.StringToData(s));
+    }
 }

--- a/src/SharpBrick.PoweredUp/Devices/Current.cs
+++ b/src/SharpBrick.PoweredUp/Devices/Current.cs
@@ -8,18 +8,18 @@ namespace SharpBrick.PoweredUp
 {
     public class Current : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<short> _currentLMode;
-        protected SingleValueMode<short> _currentSMode;
+        protected SingleValueMode<short, short> _currentLMode;
+        protected SingleValueMode<short, short> _currentSMode;
         public byte ModeIndexCurrentL { get; protected set; } = 0x00;
         public byte ModeIndexCurrentS { get; protected set; } = 0x01;
 
         public short CurrentL => _currentLMode.SI;
         public short CurrentLPct => _currentLMode.Pct;
-        public IObservable<Value<short>> CurrentLObservable => _currentLMode.Observable;
+        public IObservable<Value<short, short>> CurrentLObservable => _currentLMode.Observable;
 
         public short CurrentS => _currentSMode.SI;
         public short CurrentSPct => _currentSMode.Pct;
-        public IObservable<Value<short>> CurrentSObservable => _currentSMode.Observable;
+        public IObservable<Value<short, short>> CurrentSObservable => _currentSMode.Observable;
 
         public Current()
         { }
@@ -27,8 +27,8 @@ namespace SharpBrick.PoweredUp
         public Current(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _currentLMode = SingleValueMode<short>(ModeIndexCurrentL);
-            _currentSMode = SingleValueMode<short>(ModeIndexCurrentS);
+            _currentLMode = SingleValueMode<short, short>(ModeIndexCurrentL);
+            _currentSMode = SingleValueMode<short, short>(ModeIndexCurrentS);
 
             ObserveForPropertyChanged(_currentLMode.Observable, nameof(CurrentL), nameof(CurrentLPct));
             ObserveForPropertyChanged(_currentSMode.Observable, nameof(CurrentS), nameof(CurrentSPct));

--- a/src/SharpBrick.PoweredUp/Devices/Device.cs
+++ b/src/SharpBrick.PoweredUp/Devices/Device.cs
@@ -46,10 +46,10 @@ namespace SharpBrick.PoweredUp
             BuildModes();
         }
 
-        public SingleValueMode<TPayload> SingleValueMode<TPayload>(byte modeIndex)
-            => _modes.TryGetValue(modeIndex, out var mode) ? mode as SingleValueMode<TPayload> : default;
-        public MultiValueMode<TPayload> MultiValueMode<TPayload>(byte modeIndex)
-            => _modes.TryGetValue(modeIndex, out var mode) ? mode as MultiValueMode<TPayload> : default;
+        public SingleValueMode<TDatasetType, TOutputType> SingleValueMode<TDatasetType, TOutputType>(byte modeIndex)
+            => _modes.TryGetValue(modeIndex, out var mode) ? mode as SingleValueMode<TDatasetType, TOutputType> : default;
+        public MultiValueMode<TDatasetType, TOutputType> MultiValueMode<TDatasetType, TOutputType>(byte modeIndex)
+            => _modes.TryGetValue(modeIndex, out var mode) ? mode as MultiValueMode<TDatasetType, TOutputType> : default;
 
         protected void BuildModes()
         {

--- a/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseColorSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseColorSensor.cs
@@ -9,10 +9,10 @@ namespace SharpBrick.PoweredUp
 {
     public class DuploTrainBaseColorSensor : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<sbyte> _colorMode;
-        protected SingleValueMode<sbyte> _colorTagMode;
-        protected SingleValueMode<sbyte> _reflectionMode;
-        protected MultiValueMode<short> _rgbMode;
+        protected SingleValueMode<sbyte, sbyte> _colorMode;
+        protected SingleValueMode<sbyte, sbyte> _colorTagMode;
+        protected SingleValueMode<sbyte, sbyte> _reflectionMode;
+        protected MultiValueMode<short, short> _rgbMode;
 
         public byte ModeIndexColor { get; protected set; } = 0;
         public byte ModeIndexColorTag { get; protected set; } = 1;
@@ -37,10 +37,10 @@ namespace SharpBrick.PoweredUp
         public DuploTrainBaseColorSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _colorMode = SingleValueMode<sbyte>(ModeIndexColor);
-            _colorTagMode = SingleValueMode<sbyte>(ModeIndexColorTag);
-            _reflectionMode = SingleValueMode<sbyte>(ModeIndexReflection);
-            _rgbMode = MultiValueMode<short>(ModeIndexRgb);
+            _colorMode = SingleValueMode<sbyte, sbyte>(ModeIndexColor);
+            _colorTagMode = SingleValueMode<sbyte, sbyte>(ModeIndexColorTag);
+            _reflectionMode = SingleValueMode<sbyte, sbyte>(ModeIndexReflection);
+            _rgbMode = MultiValueMode<short, short>(ModeIndexRgb);
 
             ObserveForPropertyChanged(_colorMode.Observable, nameof(Color));
             ObserveForPropertyChanged(_colorTagMode.Observable, nameof(ColorTag));

--- a/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseMotor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseMotor.cs
@@ -12,7 +12,7 @@ namespace SharpBrick.PoweredUp
 {
     public class DuploTrainBaseMotor : Device, IPoweredUpDevice
     {
-        public SingleValueMode<int> _onSecMode;
+        public SingleValueMode<int, int> _onSecMode;
 
         public byte ModeIndexMotor { get; protected set; } = 0;
         public byte ModeIndexOnSec { get; protected set; } = 1;
@@ -26,7 +26,7 @@ namespace SharpBrick.PoweredUp
         public DuploTrainBaseMotor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _onSecMode = SingleValueMode<int>(ModeIndexOnSec);
+            _onSecMode = SingleValueMode<int, int>(ModeIndexOnSec);
 
             ObserveForPropertyChanged(_onSecMode.Observable, nameof(OnSeconds));
         }

--- a/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseSpeaker.cs
+++ b/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseSpeaker.cs
@@ -11,7 +11,7 @@ namespace SharpBrick.PoweredUp
 
     public class DuploTrainBaseSpeaker : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<sbyte> _soundMode;
+        protected SingleValueMode<sbyte, sbyte> _soundMode;
 
         public byte ModeIndexTone { get; protected set; } = 0;
         public byte ModeIndexSound { get; protected set; } = 1;
@@ -23,7 +23,7 @@ namespace SharpBrick.PoweredUp
         public DuploTrainBaseSpeaker(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _soundMode = SingleValueMode<sbyte>(ModeIndexSound);
+            _soundMode = SingleValueMode<sbyte, sbyte>(ModeIndexSound);
         }
 
         public async Task<PortFeedback> PlaySoundAsync(DuploTrainBaseSound sound)

--- a/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseSpeedometer.cs
+++ b/src/SharpBrick.PoweredUp/Devices/DuploTrainBaseSpeedometer.cs
@@ -10,15 +10,15 @@ namespace SharpBrick.PoweredUp
 {
     public class DuploTrainBaseSpeedometer : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<short> _speedMode;
-        protected SingleValueMode<int> _countMode;
+        protected SingleValueMode<short, short> _speedMode;
+        protected SingleValueMode<int, int> _countMode;
 
         public byte ModeIndexSpeed { get; protected set; } = 0;
         public byte ModeIndexCount { get; protected set; } = 1;
 
         public short Speed => _speedMode.SI;
         public short SpeedPct => _speedMode.Pct;
-        public IObservable<Value<short>> SpeedObservable => _speedMode.Observable;
+        public IObservable<Value<short, short>> SpeedObservable => _speedMode.Observable;
 
         public int Count => _countMode.SI;
         public IObservable<int> CountObservable => _countMode.Observable.Select(v => v.SI);
@@ -29,8 +29,8 @@ namespace SharpBrick.PoweredUp
         public DuploTrainBaseSpeedometer(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _speedMode = SingleValueMode<short>(ModeIndexSpeed);
-            _countMode = SingleValueMode<int>(ModeIndexCount);
+            _speedMode = SingleValueMode<short, short>(ModeIndexSpeed);
+            _countMode = SingleValueMode<int, int>(ModeIndexCount);
 
             ObserveForPropertyChanged(_speedMode.Observable, nameof(Speed), nameof(SpeedPct));
             ObserveForPropertyChanged(_countMode.Observable, nameof(Count));

--- a/src/SharpBrick.PoweredUp/Devices/MarioHubAccelerometer.cs
+++ b/src/SharpBrick.PoweredUp/Devices/MarioHubAccelerometer.cs
@@ -9,8 +9,8 @@ namespace SharpBrick.PoweredUp
 {
     public class MarioHubAccelerometer : Device, IPoweredUpDevice
     {
-        protected MultiValueMode<sbyte> _rawMode;
-        protected MultiValueMode<short> _gestMode;
+        protected MultiValueMode<sbyte, sbyte> _rawMode;
+        protected MultiValueMode<short, short> _gestMode;
 
         public byte ModeIndexRaw { get; protected set; } = 0;
         public byte ModeIndexGesture { get; protected set; } = 1;
@@ -26,8 +26,8 @@ namespace SharpBrick.PoweredUp
         public MarioHubAccelerometer(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _rawMode = MultiValueMode<sbyte>(ModeIndexRaw);
-            _gestMode = MultiValueMode<short>(ModeIndexGesture);
+            _rawMode = MultiValueMode<sbyte, sbyte>(ModeIndexRaw);
+            _gestMode = MultiValueMode<short, short>(ModeIndexGesture);
 
             //ObserveForPropertyChanged(_rawMode.Observable, nameof(Coins));
         }

--- a/src/SharpBrick.PoweredUp/Devices/MarioHubPants.cs
+++ b/src/SharpBrick.PoweredUp/Devices/MarioHubPants.cs
@@ -10,7 +10,7 @@ namespace SharpBrick.PoweredUp
     // https://github.com/bricklife/LEGO-Mario-Reveng/blob/master/IOType-0x4a.md
     public class MarioHubPants : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<sbyte> _pantsMode;
+        protected SingleValueMode<sbyte, sbyte> _pantsMode;
 
         public byte ModeIndexPants { get; protected set; } = 0;
 
@@ -23,7 +23,7 @@ namespace SharpBrick.PoweredUp
         public MarioHubPants(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _pantsMode = SingleValueMode<sbyte>(ModeIndexPants);
+            _pantsMode = SingleValueMode<sbyte, sbyte>(ModeIndexPants);
 
             ObserveForPropertyChanged(_pantsMode.Observable, nameof(Pants));
         }

--- a/src/SharpBrick.PoweredUp/Devices/MarioHubTagSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/MarioHubTagSensor.cs
@@ -10,8 +10,8 @@ namespace SharpBrick.PoweredUp
 {
     public class MarioHubTagSensor : Device, IPoweredUpDevice
     {
-        protected MultiValueMode<short> _tagMode;
-        protected MultiValueMode<sbyte> _rgbMode;
+        protected MultiValueMode<short, short> _tagMode;
+        protected MultiValueMode<sbyte, sbyte> _rgbMode;
 
         public byte ModeIndexTag { get; protected set; } = 0;
         public byte ModeIndexRgb { get; protected set; } = 1;
@@ -31,8 +31,8 @@ namespace SharpBrick.PoweredUp
         public MarioHubTagSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _tagMode = MultiValueMode<short>(ModeIndexTag);
-            _rgbMode = MultiValueMode<sbyte>(ModeIndexRgb);
+            _tagMode = MultiValueMode<short, short>(ModeIndexTag);
+            _rgbMode = MultiValueMode<sbyte, sbyte>(ModeIndexRgb);
 
             ObserveForPropertyChanged(_tagMode.Observable, nameof(Barcode));
             ObserveForPropertyChanged(_tagMode.Observable, nameof(ColorNo));

--- a/src/SharpBrick.PoweredUp/Devices/Mode.cs
+++ b/src/SharpBrick.PoweredUp/Devices/Mode.cs
@@ -27,19 +27,32 @@ namespace SharpBrick.PoweredUp
         {
             var modeInfo = protocol.Knowledge.PortMode(hubId, portId, modeIndex);
 
-            Mode result = (modeInfo.DatasetType, modeInfo.NumberOfDatasets) switch
+            Mode result = modeInfo switch
             {
-                (PortModeInformationDataType.SByte, 1) => new SingleValueMode<sbyte>(protocol, modeInfo, modeValueObservable),
-                (PortModeInformationDataType.SByte, _) => new MultiValueMode<sbyte>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.SByte, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: false } => new SingleValueMode<sbyte, sbyte>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.SByte, NumberOfDatasets: _, OverrideDatasetTypeToDouble: false } => new MultiValueMode<sbyte, sbyte>(protocol, modeInfo, modeValueObservable),
 
-                (PortModeInformationDataType.Int16, 1) => new SingleValueMode<short>(protocol, modeInfo, modeValueObservable),
-                (PortModeInformationDataType.Int16, _) => new MultiValueMode<short>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Int16, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: false } => new SingleValueMode<short, short>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Int16, NumberOfDatasets: _, OverrideDatasetTypeToDouble: false } => new MultiValueMode<short, short>(protocol, modeInfo, modeValueObservable),
 
-                (PortModeInformationDataType.Int32, 1) => new SingleValueMode<int>(protocol, modeInfo, modeValueObservable),
-                (PortModeInformationDataType.Int32, _) => new MultiValueMode<int>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Int32, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: false } => new SingleValueMode<int, int>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Int32, NumberOfDatasets: _, OverrideDatasetTypeToDouble: false } => new MultiValueMode<int, int>(protocol, modeInfo, modeValueObservable),
 
-                (PortModeInformationDataType.Single, 1) => new SingleValueMode<float>(protocol, modeInfo, modeValueObservable),
-                (PortModeInformationDataType.Single, _) => new MultiValueMode<float>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Single, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: false } => new SingleValueMode<float, float>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Single, NumberOfDatasets: _, OverrideDatasetTypeToDouble: false } => new MultiValueMode<float, float>(protocol, modeInfo, modeValueObservable),
+
+                // override to allow scaling crossing the boundary of the original data type
+                { DatasetType: PortModeInformationDataType.SByte, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: true } => new SingleValueMode<sbyte, double>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.SByte, NumberOfDatasets: _, OverrideDatasetTypeToDouble: true } => new MultiValueMode<sbyte, double>(protocol, modeInfo, modeValueObservable),
+
+                { DatasetType: PortModeInformationDataType.Int16, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: true } => new SingleValueMode<short, double>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Int16, NumberOfDatasets: _, OverrideDatasetTypeToDouble: true } => new MultiValueMode<short, double>(protocol, modeInfo, modeValueObservable),
+
+                { DatasetType: PortModeInformationDataType.Int32, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: true } => new SingleValueMode<int, double>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Int32, NumberOfDatasets: _, OverrideDatasetTypeToDouble: true } => new MultiValueMode<int, double>(protocol, modeInfo, modeValueObservable),
+
+                { DatasetType: PortModeInformationDataType.Single, NumberOfDatasets: 1, OverrideDatasetTypeToDouble: true } => new SingleValueMode<float, double>(protocol, modeInfo, modeValueObservable),
+                { DatasetType: PortModeInformationDataType.Single, NumberOfDatasets: _, OverrideDatasetTypeToDouble: true } => new MultiValueMode<float, double>(protocol, modeInfo, modeValueObservable),
 
                 _ => throw new NotSupportedException("Mode of unknown data type"),
             };

--- a/src/SharpBrick.PoweredUp/Devices/MoveHubTiltSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/MoveHubTiltSensor.cs
@@ -12,11 +12,11 @@ namespace SharpBrick.PoweredUp
 {
     public class MoveHubTiltSensor : Device, IPoweredUpDevice
     {
-        protected MultiValueMode<sbyte> _twoAxisFullMode;
-        protected SingleValueMode<sbyte> _twoAxisStateMode;
-        protected SingleValueMode<sbyte> _threeAxisStateMode;
-        protected SingleValueMode<int> _impactsMode;
-        protected MultiValueMode<sbyte> _threeAxisFullMode;
+        protected MultiValueMode<sbyte, sbyte> _twoAxisFullMode;
+        protected SingleValueMode<sbyte, sbyte> _twoAxisStateMode;
+        protected SingleValueMode<sbyte, sbyte> _threeAxisStateMode;
+        protected SingleValueMode<int, int> _impactsMode;
+        protected MultiValueMode<sbyte, sbyte> _threeAxisFullMode;
 
         /// <summary>
         /// Two axis full values
@@ -51,7 +51,7 @@ namespace SharpBrick.PoweredUp
         public IObservable<(sbyte roll, sbyte pitch)> TwoAxisFullObservable => _twoAxisFullMode.Observable.Select(v => (v.SI[0], v.SI[1]));
         public IObservable<MoveHubTiltSimpleOrientation> TwoAxisStateObservable => _twoAxisStateMode.Observable.Select(x => (MoveHubTiltSimpleOrientation)x.SI);
         public IObservable<MoveHubTiltOrientation> ThreeAxisStateObservable => _threeAxisStateMode.Observable.Select(x => (MoveHubTiltOrientation)x.SI);
-        public IObservable<Value<int>> ImpactsObservable => _impactsMode.Observable;
+        public IObservable<Value<int, int>> ImpactsObservable => _impactsMode.Observable;
         public IObservable<(sbyte roll, sbyte pitch, sbyte yaw)> ThreeAxisFullObservable => _threeAxisFullMode.Observable.Select(v => (v.SI[0], v.SI[1], v.SI[2]));
 
         public MoveHubTiltSensor()
@@ -60,11 +60,11 @@ namespace SharpBrick.PoweredUp
         public MoveHubTiltSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _twoAxisFullMode = MultiValueMode<sbyte>(ModeIndexTwoAxisFull);
-            _twoAxisStateMode = SingleValueMode<sbyte>(ModeIndexTwoAxisState);
-            _threeAxisStateMode = SingleValueMode<sbyte>(ModeIndexThreeAxisState);
-            _impactsMode = SingleValueMode<int>(ModeIndexImpacts);
-            _threeAxisFullMode = MultiValueMode<sbyte>(ModeIndexThreeAxisFull);
+            _twoAxisFullMode = MultiValueMode<sbyte, sbyte>(ModeIndexTwoAxisFull);
+            _twoAxisStateMode = SingleValueMode<sbyte, sbyte>(ModeIndexTwoAxisState);
+            _threeAxisStateMode = SingleValueMode<sbyte, sbyte>(ModeIndexThreeAxisState);
+            _impactsMode = SingleValueMode<int, int>(ModeIndexImpacts);
+            _threeAxisFullMode = MultiValueMode<sbyte, sbyte>(ModeIndexThreeAxisFull);
 
             ObserveForPropertyChanged(_twoAxisFullMode.Observable, nameof(TwoAxisFull));
             ObserveForPropertyChanged(_twoAxisStateMode.Observable, nameof(TwoAxisState));

--- a/src/SharpBrick.PoweredUp/Devices/MultiValueMode.cs
+++ b/src/SharpBrick.PoweredUp/Devices/MultiValueMode.cs
@@ -6,13 +6,13 @@ using SharpBrick.PoweredUp.Protocol.Messages;
 
 namespace SharpBrick.PoweredUp
 {
-    public class MultiValueMode<TPayload> : Mode
+    public class MultiValueMode<TDatasetType, TOutputType> : Mode
     {
-        public TPayload[] Raw { get; private set; }
-        public TPayload[] SI { get; private set; }
-        public TPayload[] Pct { get; private set; }
+        public TDatasetType[] Raw { get; private set; }
+        public TOutputType[] SI { get; private set; }
+        public TOutputType[] Pct { get; private set; }
 
-        public IObservable<Value<TPayload[]>> Observable { get; }
+        public IObservable<Value<TDatasetType[], TOutputType[]>> Observable { get; }
 
         public MultiValueMode(ILegoWirelessProtocol protocol, PortModeInfo modeInfo, IObservable<PortValueData> modeValueObservable)
                 : base(protocol, modeInfo, modeValueObservable)
@@ -21,10 +21,10 @@ namespace SharpBrick.PoweredUp
             ObserveOnLocalProperty(Observable, v => Raw = v.Raw, v => SI = v.SI, v => Pct = v.Pct);
             ObserveForPropertyChanged(Observable, nameof(Raw), nameof(SI), nameof(Pct));
         }
-        protected IObservable<Value<TPayload[]>> CreateObservable()
+        protected IObservable<Value<TDatasetType[], TOutputType[]>> CreateObservable()
             => _modeValueObservable
-                .Cast<PortValueData<TPayload>>()
-                .Select(pvd => new Value<TPayload[]>()
+                .Cast<PortValueData<TDatasetType, TOutputType>>()
+                .Select(pvd => new Value<TDatasetType[], TOutputType[]>()
                 {
                     Raw = pvd.InputValues,
                     SI = pvd.SIInputValues,

--- a/src/SharpBrick.PoweredUp/Devices/RemoteControlButton.cs
+++ b/src/SharpBrick.PoweredUp/Devices/RemoteControlButton.cs
@@ -14,7 +14,7 @@ namespace SharpBrick.PoweredUp.Devices
         protected sbyte RedBitMask = 0b0000_0010;
         protected sbyte MinusBitMask = 0b0000_0100;
 
-        protected SingleValueMode<sbyte> _keyBitFieldMode;
+        protected SingleValueMode<sbyte, sbyte> _keyBitFieldMode;
         public byte ModeIndexBitField { get; protected set; } = 3;
 
         public bool Plus => IsBitMaskSet(_keyBitFieldMode.SI, PlusBitMask);
@@ -32,7 +32,7 @@ namespace SharpBrick.PoweredUp.Devices
         public RemoteControlButton(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _keyBitFieldMode = SingleValueMode<sbyte>(ModeIndexBitField);
+            _keyBitFieldMode = SingleValueMode<sbyte, sbyte>(ModeIndexBitField);
 
             ObserveForPropertyChanged(PlusObservable, nameof(Plus));
             ObserveForPropertyChanged(RedObservable, nameof(Red));

--- a/src/SharpBrick.PoweredUp/Devices/RemoteControlRssi.cs
+++ b/src/SharpBrick.PoweredUp/Devices/RemoteControlRssi.cs
@@ -10,7 +10,7 @@ namespace SharpBrick.PoweredUp.Devices
 {
     public class RemoteControlRssi : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<sbyte> _rssiMode;
+        protected SingleValueMode<sbyte, sbyte> _rssiMode;
         public byte ModeIndexRssi { get; protected set; } = 0;
 
         public sbyte Rssi => _rssiMode.SI;
@@ -22,7 +22,7 @@ namespace SharpBrick.PoweredUp.Devices
         public RemoteControlRssi(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _rssiMode = SingleValueMode<sbyte>(ModeIndexRssi);
+            _rssiMode = SingleValueMode<sbyte, sbyte>(ModeIndexRssi);
 
             ObserveForPropertyChanged(_rssiMode.Observable, nameof(Rssi));
         }

--- a/src/SharpBrick.PoweredUp/Devices/SingleValueMode.cs
+++ b/src/SharpBrick.PoweredUp/Devices/SingleValueMode.cs
@@ -6,13 +6,13 @@ using SharpBrick.PoweredUp.Protocol.Messages;
 
 namespace SharpBrick.PoweredUp
 {
-    public class SingleValueMode<TPayload> : Mode
+    public class SingleValueMode<TDatasetType, TOutputType> : Mode
     {
-        public TPayload Raw { get; private set; }
-        public TPayload SI { get; private set; }
-        public TPayload Pct { get; private set; }
+        public TDatasetType Raw { get; private set; }
+        public TOutputType SI { get; private set; }
+        public TOutputType Pct { get; private set; }
 
-        public IObservable<Value<TPayload>> Observable { get; }
+        public IObservable<Value<TDatasetType, TOutputType>> Observable { get; }
 
         public SingleValueMode(ILegoWirelessProtocol protocol, PortModeInfo modeInfo, IObservable<PortValueData> modeValueObservable)
                 : base(protocol, modeInfo, modeValueObservable)
@@ -21,10 +21,10 @@ namespace SharpBrick.PoweredUp
             ObserveOnLocalProperty(Observable, v => Raw = v.Raw, v => SI = v.SI, v => Pct = v.Pct);
             ObserveForPropertyChanged(Observable, nameof(Raw), nameof(SI), nameof(Pct));
         }
-        protected IObservable<Value<TPayload>> CreateObservable()
+        protected IObservable<Value<TDatasetType, TOutputType>> CreateObservable()
             => _modeValueObservable
-                .Cast<PortValueData<TPayload>>()
-                .Select(pvd => new Value<TPayload>()
+                .Cast<PortValueData<TDatasetType, TOutputType>>()
+                .Select(pvd => new Value<TDatasetType, TOutputType>()
                 {
                     Raw = pvd.InputValues[0],
                     SI = pvd.SIInputValues[0],

--- a/src/SharpBrick.PoweredUp/Devices/TachoMotor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TachoMotor.cs
@@ -7,18 +7,18 @@ namespace SharpBrick.PoweredUp
 {
     public abstract class TachoMotor : BasicMotor
     {
-        protected SingleValueMode<sbyte> _speedMode;
-        protected SingleValueMode<int> _positionMode;
+        protected SingleValueMode<sbyte, sbyte> _speedMode;
+        protected SingleValueMode<int, int> _positionMode;
         public byte ModeIndexSpeed { get; protected set; } = 1;
         public byte ModeIndexPosition { get; protected set; } = 2;
 
         public sbyte Speed => _speedMode.SI;
         public sbyte SpeedPct => _speedMode.Pct;
-        public IObservable<Value<sbyte>> SpeedObservable => _speedMode.Observable;
+        public IObservable<Value<sbyte, sbyte>> SpeedObservable => _speedMode.Observable;
 
         public int Position => _positionMode.SI;
         public int PositionPct => _positionMode.Pct;
-        public IObservable<Value<int>> PositionObservable => _positionMode.Observable;
+        public IObservable<Value<int, int>> PositionObservable => _positionMode.Observable;
 
         public TachoMotor()
         { }
@@ -26,8 +26,8 @@ namespace SharpBrick.PoweredUp
         protected TachoMotor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _speedMode = SingleValueMode<sbyte>(ModeIndexSpeed);
-            _positionMode = SingleValueMode<int>(ModeIndexPosition);
+            _speedMode = SingleValueMode<sbyte, sbyte>(ModeIndexSpeed);
+            _positionMode = SingleValueMode<int, int>(ModeIndexPosition);
 
             ObserveForPropertyChanged(_speedMode.Observable, nameof(Speed), nameof(SpeedPct));
             ObserveForPropertyChanged(_positionMode.Observable, nameof(Position), nameof(PositionPct));

--- a/src/SharpBrick.PoweredUp/Devices/TechnicColorSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicColorSensor.cs
@@ -11,15 +11,15 @@ namespace SharpBrick.PoweredUp
 {
     public class TechnicColorSensor : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<sbyte> _colorMode;
-        protected SingleValueMode<sbyte> _reflectionMode;
-        protected SingleValueMode<sbyte> _ambientLightMode;
-        protected MultiValueMode<sbyte> _lightMode;
+        protected SingleValueMode<sbyte, sbyte> _colorMode;
+        protected SingleValueMode<sbyte, sbyte> _reflectionMode;
+        protected SingleValueMode<sbyte, sbyte> _ambientLightMode;
+        protected MultiValueMode<sbyte, sbyte> _lightMode;
 
-        protected MultiValueMode<short> _rawReflectionMode;
-        protected MultiValueMode<short> _rgbMode;
-        protected MultiValueMode<short> _hsvMode;
-        protected MultiValueMode<short> _shsvMode;
+        protected MultiValueMode<short, short> _rawReflectionMode;
+        protected MultiValueMode<short, short> _rgbMode;
+        protected MultiValueMode<short, short> _hsvMode;
+        protected MultiValueMode<short, short> _shsvMode;
 
         public byte ModeIndexColor { get; protected set; } = 0;
         public byte ModeIndexReflection { get; protected set; } = 1;
@@ -48,12 +48,12 @@ namespace SharpBrick.PoweredUp
         public TechnicColorSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _colorMode = SingleValueMode<sbyte>(ModeIndexColor);
-            _reflectionMode = SingleValueMode<sbyte>(ModeIndexReflection);
-            _ambientLightMode = SingleValueMode<sbyte>(ModeIndexAmbientLight);
-            _lightMode = MultiValueMode<sbyte>(ModeIndexLight);
-            _rgbMode = MultiValueMode<short>(ModeIndexRgbIntern);
-            _hsvMode = MultiValueMode<short>(ModeIndexHSV);
+            _colorMode = SingleValueMode<sbyte, sbyte>(ModeIndexColor);
+            _reflectionMode = SingleValueMode<sbyte, sbyte>(ModeIndexReflection);
+            _ambientLightMode = SingleValueMode<sbyte, sbyte>(ModeIndexAmbientLight);
+            _lightMode = MultiValueMode<sbyte, sbyte>(ModeIndexLight);
+            _rgbMode = MultiValueMode<short, short>(ModeIndexRgbIntern);
+            _hsvMode = MultiValueMode<short, short>(ModeIndexHSV);
         }
 
         public async Task SetSectorLightAsync(byte sector1, byte sector2, byte sector3)

--- a/src/SharpBrick.PoweredUp/Devices/TechnicDistanceSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicDistanceSensor.cs
@@ -10,10 +10,10 @@ namespace SharpBrick.PoweredUp
 {
     public class TechnicDistanceSensor : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<short> _distlMode;
-        protected SingleValueMode<short> _distsMode;
-        protected SingleValueMode<short> _singlMode;
-        protected MultiValueMode<sbyte> _lightMode;
+        protected SingleValueMode<short, short> _distlMode;
+        protected SingleValueMode<short, short> _distsMode;
+        protected SingleValueMode<short, short> _singlMode;
+        protected MultiValueMode<sbyte, sbyte> _lightMode;
 
         public byte ModeIndexDistance { get; protected set; } = 0;
         public byte ModeIndexShortOnlyDistance { get; protected set; } = 1;
@@ -32,10 +32,10 @@ namespace SharpBrick.PoweredUp
         public TechnicDistanceSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _distlMode = SingleValueMode<short>(ModeIndexDistance);
-            _distsMode = SingleValueMode<short>(ModeIndexShortOnlyDistance);
-            _singlMode = SingleValueMode<short>(ModeIndexSingleMeasurement);
-            _lightMode = MultiValueMode<sbyte>(ModeIndexLight);
+            _distlMode = SingleValueMode<short, short>(ModeIndexDistance);
+            _distsMode = SingleValueMode<short, short>(ModeIndexShortOnlyDistance);
+            _singlMode = SingleValueMode<short, short>(ModeIndexSingleMeasurement);
+            _lightMode = MultiValueMode<sbyte, sbyte>(ModeIndexLight);
 
             ObserveForPropertyChanged(_distlMode.Observable, nameof(Distance));
             ObserveForPropertyChanged(_distsMode.Observable, nameof(ShortOnlyDistance));

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubAccelerometer.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubAccelerometer.cs
@@ -10,7 +10,7 @@ namespace SharpBrick.PoweredUp
     // accelerometers measure translation
     public class TechnicMediumHubAccelerometer : Device, IPoweredUpDevice
     {
-        protected MultiValueMode<short> _gravityMode;
+        protected MultiValueMode<short, short> _gravityMode;
 
         public byte ModeIndexGravity { get; protected set; } = 0;
         public byte ModeIndexCalibration { get; protected set; } = 1;
@@ -24,7 +24,7 @@ namespace SharpBrick.PoweredUp
         public TechnicMediumHubAccelerometer(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _gravityMode = MultiValueMode<short>(ModeIndexGravity);
+            _gravityMode = MultiValueMode<short, short>(ModeIndexGravity);
 
             ObserveForPropertyChanged(_gravityMode.Observable, nameof(Gravity));
         }

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGestSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGestSensor.cs
@@ -11,7 +11,7 @@ namespace SharpBrick.PoweredUp
 {
     public class TechnicMediumHubGestureSensor : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<sbyte> _gestureMode;
+        protected SingleValueMode<sbyte, sbyte> _gestureMode;
         public byte ModeIndexGesture { get; protected set; } = 0;
 
         public Gesture Gesture => (Gesture)_gestureMode.SI;
@@ -23,7 +23,7 @@ namespace SharpBrick.PoweredUp
         public TechnicMediumHubGestureSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _gestureMode = SingleValueMode<sbyte>(ModeIndexGesture);
+            _gestureMode = SingleValueMode<sbyte, sbyte>(ModeIndexGesture);
 
             ObserveForPropertyChanged(_gestureMode.Observable, nameof(Gesture));
         }

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGyroSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubGyroSensor.cs
@@ -10,7 +10,7 @@ namespace SharpBrick.PoweredUp
     // gyroscopes measure rotation
     public class TechnicMediumHubGyroSensor : Device, IPoweredUpDevice
     {
-        protected MultiValueMode<short> _rotationMode;
+        protected MultiValueMode<short, short> _rotationMode;
         public byte ModeIndexRotation { get; protected set; } = 0;
 
         public (short x, short y, short z) Rotation => (_rotationMode.SI[0], _rotationMode.SI[1], _rotationMode.SI[2]);
@@ -22,7 +22,7 @@ namespace SharpBrick.PoweredUp
         public TechnicMediumHubGyroSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _rotationMode = MultiValueMode<short>(ModeIndexRotation);
+            _rotationMode = MultiValueMode<short, short>(ModeIndexRotation);
 
             ObserveForPropertyChanged(_rotationMode.Observable, nameof(Rotation));
         }

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTemperatureSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTemperatureSensor.cs
@@ -8,12 +8,12 @@ namespace SharpBrick.PoweredUp
 {
     public class TechnicMediumHubTemperatureSensor : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<short> _temperatureMode;
+        protected SingleValueMode<short, short> _temperatureMode;
         public byte ModeIndexTemperature { get; protected set; } = 0;
 
         public short Temperature => _temperatureMode.SI;
         public short TemperaturePct => _temperatureMode.Pct;
-        public IObservable<Value<short>> TemperatureObservable => _temperatureMode.Observable;
+        public IObservable<Value<short, short>> TemperatureObservable => _temperatureMode.Observable;
 
         public TechnicMediumHubTemperatureSensor()
         { }
@@ -21,7 +21,7 @@ namespace SharpBrick.PoweredUp
         public TechnicMediumHubTemperatureSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _temperatureMode = SingleValueMode<short>(ModeIndexTemperature);
+            _temperatureMode = SingleValueMode<short, short>(ModeIndexTemperature);
 
             ObserveForPropertyChanged(_temperatureMode.Observable, nameof(Temperature), nameof(TemperaturePct));
         }

--- a/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTiltSensor.cs
+++ b/src/SharpBrick.PoweredUp/Devices/TechnicMediumHubTiltSensor.cs
@@ -11,8 +11,8 @@ namespace SharpBrick.PoweredUp
 {
     public class TechnicMediumHubTiltSensor : Device, IPoweredUpDevice
     {
-        protected MultiValueMode<short> _positionMode;
-        protected SingleValueMode<int> _impactsMode;
+        protected MultiValueMode<short, short> _positionMode;
+        protected SingleValueMode<int, int> _impactsMode;
         public byte ModeIndexPosition { get; protected set; } = 0;
         public byte ModeIndexImpacts { get; protected set; } = 1;
         public byte ModeIndexConfig { get; protected set; } = 2;
@@ -20,7 +20,7 @@ namespace SharpBrick.PoweredUp
         public (short x, short y, short z) Position => (_positionMode.SI[0], _positionMode.SI[1], _positionMode.SI[2]);
         public int Impacts => _impactsMode.SI;
         public IObservable<(short x, short y, short z)> PositionObservable => _positionMode.Observable.Select(v => (v.SI[0], v.SI[1], v.SI[2]));
-        public IObservable<Value<int>> ImpactsObservable => _impactsMode.Observable;
+        public IObservable<Value<int, int>> ImpactsObservable => _impactsMode.Observable;
 
         public TechnicMediumHubTiltSensor()
         { }
@@ -28,8 +28,8 @@ namespace SharpBrick.PoweredUp
         public TechnicMediumHubTiltSensor(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _positionMode = MultiValueMode<short>(ModeIndexPosition);
-            _impactsMode = SingleValueMode<int>(ModeIndexImpacts);
+            _positionMode = MultiValueMode<short, short>(ModeIndexPosition);
+            _impactsMode = SingleValueMode<int, int>(ModeIndexImpacts);
 
             ObserveForPropertyChanged(_positionMode.Observable, nameof(Position));
             ObserveForPropertyChanged(_impactsMode.Observable, nameof(Impacts));

--- a/src/SharpBrick.PoweredUp/Devices/Value.cs
+++ b/src/SharpBrick.PoweredUp/Devices/Value.cs
@@ -1,9 +1,9 @@
 namespace SharpBrick.PoweredUp
 {
-    public class Value<TPayload>
+    public class Value<TDatasetType, TOutputType>
     {
-        public TPayload Raw { get; set; }
-        public TPayload SI { get; set; }
-        public TPayload Pct { get; set; }
+        public TDatasetType Raw { get; set; }
+        public TOutputType SI { get; set; }
+        public TOutputType Pct { get; set; }
     }
 }

--- a/src/SharpBrick.PoweredUp/Devices/Voltage.cs
+++ b/src/SharpBrick.PoweredUp/Devices/Voltage.cs
@@ -8,18 +8,18 @@ namespace SharpBrick.PoweredUp
 {
     public class Voltage : Device, IPoweredUpDevice
     {
-        protected SingleValueMode<short> _voltageLMode;
-        protected SingleValueMode<short> _voltageSMode;
+        protected SingleValueMode<short, short> _voltageLMode;
+        protected SingleValueMode<short, short> _voltageSMode;
         public byte ModeIndexVoltageL { get; protected set; } = 0;
         public byte ModeIndexVoltageS { get; protected set; } = 1;
 
         public short VoltageL => _voltageLMode.SI;
         public short VoltageLPct => _voltageLMode.Pct;
-        public IObservable<Value<short>> VoltageLObservable => _voltageLMode.Observable;
+        public IObservable<Value<short, short>> VoltageLObservable => _voltageLMode.Observable;
 
         public short VoltageS => _voltageSMode.SI;
         public short VoltageSPct => _voltageSMode.Pct;
-        public IObservable<Value<short>> VoltageSObservable => _voltageSMode.Observable;
+        public IObservable<Value<short, short>> VoltageSObservable => _voltageSMode.Observable;
 
         public Voltage()
         { }
@@ -27,8 +27,8 @@ namespace SharpBrick.PoweredUp
         public Voltage(ILegoWirelessProtocol protocol, byte hubId, byte portId)
             : base(protocol, hubId, portId)
         {
-            _voltageLMode = SingleValueMode<short>(ModeIndexVoltageL);
-            _voltageSMode = SingleValueMode<short>(ModeIndexVoltageS);
+            _voltageLMode = SingleValueMode<short, short>(ModeIndexVoltageL);
+            _voltageSMode = SingleValueMode<short, short>(ModeIndexVoltageS);
 
             ObserveForPropertyChanged(_voltageLMode.Observable, nameof(VoltageL), nameof(VoltageLPct));
             ObserveForPropertyChanged(_voltageSMode.Observable, nameof(VoltageS), nameof(VoltageSPct));

--- a/src/SharpBrick.PoweredUp/Protocol/Formatter/PortValueSingleEncoder.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/Formatter/PortValueSingleEncoder.cs
@@ -67,97 +67,67 @@ namespace SharpBrick.PoweredUp.Protocol.Formatter
                 _ => throw new NotSupportedException(),
             };
 
-        internal static PortValueData<sbyte> CreatePortValueDataSByte(PortModeInfo modeInfo, in Span<byte> dataSlice)
+        internal static PortValueData CreatePortValueDataSByte(PortModeInfo modeInfo, in Span<byte> dataSlice)
         {
             var rawValues = MemoryMarshal.Cast<byte, sbyte>(dataSlice).ToArray();
 
-            var siValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax)).Select(f => Convert.ToSByte(f)).ToArray();
-            var pctValues = modeInfo.DisablePercentage switch
-            {
-                false => rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax)).Select(f => Convert.ToSByte(f)).ToArray(),
-                true => new sbyte[rawValues.Length],
-            };
+            var scaledSIValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax));
+            var scaledPctValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax));
 
-            return new PortValueData<sbyte>(
-                PortId: modeInfo.PortId,
-                ModeIndex: modeInfo.ModeIndex,
-                DataType: modeInfo.DatasetType,
-                InputValues: rawValues,
-                SIInputValues: siValues,
-                PctInputValues: pctValues
-            );
+            return CreatePortValueData<sbyte>(modeInfo, rawValues, scaledSIValues, scaledPctValues, f => Convert.ToSByte(f));
         }
 
-        internal static PortValueData<short> CreatePortValueDataInt16(PortModeInfo modeInfo, in Span<byte> dataSlice)
+        internal static PortValueData CreatePortValueDataInt16(PortModeInfo modeInfo, in Span<byte> dataSlice)
         {
             var rawValues = MemoryMarshal.Cast<byte, short>(dataSlice).ToArray();
 
-            var siValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax)).Select(f => Convert.ToInt16(f)).ToArray();
-            var pctValues = modeInfo.DisablePercentage switch
-            {
-                false => rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax)).Select(f => Convert.ToInt16(f)).ToArray(),
-                true => new short[rawValues.Length],
-            };
+            var scaledSIValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax));
+            var scaledPctValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax));
 
-            return new PortValueData<short>(
-                PortId: modeInfo.PortId,
-                ModeIndex: modeInfo.ModeIndex,
-                DataType: modeInfo.DatasetType,
-                InputValues: rawValues,
-                SIInputValues: siValues,
-                PctInputValues: pctValues
-            );
+            return CreatePortValueData<short>(modeInfo, rawValues, scaledSIValues, scaledPctValues, f => Convert.ToInt16(f));
         }
 
-        internal static PortValueData<int> CreatePortValueDataInt32(PortModeInfo modeInfo, in Span<byte> dataSlice)
+        internal static PortValueData CreatePortValueDataInt32(PortModeInfo modeInfo, in Span<byte> dataSlice)
         {
             var rawValues = MemoryMarshal.Cast<byte, int>(dataSlice).ToArray();
 
-            var siValues = modeInfo switch
-            {
-                { DisableScaling: true } => rawValues,
-                _ => rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax)).Select(f => Convert.ToInt32(f)).ToArray(),
-            };
+            var scaledSIValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax));
+            var scaledPctValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax));
 
-            var pctValues = modeInfo switch
-            {
-                { DisablePercentage: true } => new int[rawValues.Length],
-                { DisableScaling: true } => rawValues,
-                _ => rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax)).Select(f => Convert.ToInt32(f)).ToArray(),
-            };
-
-            return new PortValueData<int>(
-                PortId: modeInfo.PortId,
-                ModeIndex: modeInfo.ModeIndex,
-                DataType: modeInfo.DatasetType,
-                InputValues: rawValues,
-                SIInputValues: siValues,
-                PctInputValues: pctValues
-            );
+            return CreatePortValueData<int>(modeInfo, rawValues, scaledSIValues, scaledPctValues, f => Convert.ToInt32(f));
         }
 
-        internal static PortValueData<float> CreatePortValueDataSingle(PortModeInfo modeInfo, in Span<byte> dataSlice)
+        internal static PortValueData CreatePortValueDataSingle(PortModeInfo modeInfo, in Span<byte> dataSlice)
         {
             var rawValues = MemoryMarshal.Cast<byte, float>(dataSlice).ToArray();
 
-            var siValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax)).ToArray();
-            var pctValues = modeInfo.DisablePercentage switch
-            {
-                false => rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax)).ToArray(),
-                true => new float[rawValues.Length],
-            };
+            var scaledSIValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.SIMin, modeInfo.SIMax));
+            var scaledPctValues = rawValues.Select(rv => Scale(rv, modeInfo.RawMin, modeInfo.RawMax, modeInfo.PctMin, modeInfo.PctMax));
 
-            return new PortValueData<float>(
-                PortId: modeInfo.PortId,
-                ModeIndex: modeInfo.ModeIndex,
-                DataType: modeInfo.DatasetType,
-                InputValues: rawValues,
-                SIInputValues: siValues,
-                PctInputValues: pctValues
-            );
+            return CreatePortValueData<float>(modeInfo, rawValues, scaledSIValues, scaledPctValues, f => Convert.ToSingle(f));
         }
 
-        internal static float Scale(float value, float rawMin, float rawMax, float min, float max)
+        internal static PortValueData CreatePortValueData<TDatasetType>(PortModeInfo modeInfo, TDatasetType[] rawValues, IEnumerable<double> scaledSIValues, IEnumerable<double> scaledPctValues, Func<double, TDatasetType> converter)
+            => modeInfo switch
+            {
+                { DisableScaling: true, OverrideDatasetTypeToDouble: _, DisablePercentage: _ } => new PortValueData<TDatasetType, TDatasetType>(modeInfo.PortId, modeInfo.ModeIndex, modeInfo.DatasetType, rawValues,
+                        rawValues.ToArray(),
+                        rawValues.ToArray()),
+                { DisableScaling: false, OverrideDatasetTypeToDouble: true, DisablePercentage: true } => new PortValueData<TDatasetType, double>(modeInfo.PortId, modeInfo.ModeIndex, modeInfo.DatasetType, rawValues,
+                        scaledSIValues.ToArray(),
+                        new double[scaledPctValues.Count()]),
+                { DisableScaling: false, OverrideDatasetTypeToDouble: true, DisablePercentage: false } => new PortValueData<TDatasetType, double>(modeInfo.PortId, modeInfo.ModeIndex, modeInfo.DatasetType, rawValues,
+                        scaledSIValues.ToArray(),
+                        scaledPctValues.ToArray()),
+                { DisableScaling: false, OverrideDatasetTypeToDouble: false, DisablePercentage: true } => new PortValueData<TDatasetType, TDatasetType>(modeInfo.PortId, modeInfo.ModeIndex, modeInfo.DatasetType, InputValues: rawValues,
+                        SIInputValues: scaledSIValues.Select(converter).ToArray(),
+                        PctInputValues: new TDatasetType[scaledPctValues.Count()]),
+                { DisableScaling: false, OverrideDatasetTypeToDouble: false, DisablePercentage: false } => new PortValueData<TDatasetType, TDatasetType>(modeInfo.PortId, modeInfo.ModeIndex, modeInfo.DatasetType, InputValues: rawValues,
+                        SIInputValues: scaledSIValues.Select(converter).ToArray(),
+                        PctInputValues: scaledPctValues.Select(converter).ToArray()),
+            };
+
+        internal static double Scale(double value, double rawMin, double rawMax, double min, double max)
         {
             var positionInRawRange = (value - rawMin) / (rawMax - rawMin);
 

--- a/src/SharpBrick.PoweredUp/Protocol/Knowledge/PortModeInfo.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/Knowledge/PortModeInfo.cs
@@ -57,5 +57,6 @@ namespace SharpBrick.PoweredUp.Protocol.Knowledge
         // Additional Settings
         public bool DisablePercentage { get; set; } = false;
         public bool DisableScaling { get; set; } = false;
+        public bool OverrideDatasetTypeToDouble { get; set; } = false;
     }
 }

--- a/src/SharpBrick.PoweredUp/Protocol/Messages/MessageOfPortValuesModel.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/Messages/MessageOfPortValuesModel.cs
@@ -8,10 +8,14 @@ namespace SharpBrick.PoweredUp.Protocol.Messages
         public static string FormatPortValueDataArray(byte hubId, in PortValueData[] data)
             => string.Join(";", data.Select(d => d switch
                 {
-                    PortValueData<sbyte> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
-                    PortValueData<short> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
-                    PortValueData<int> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
-                    PortValueData<float> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<sbyte, sbyte> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<short, short> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<int, int> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<float, float> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<sbyte, double> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<short, double> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<int, double> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
+                    PortValueData<float, double> dd => $"Mode {hubId}/{dd.PortId}/{dd.ModeIndex}: {string.Join(",", dd.InputValues)} ({dd.DataType})",
                     _ => "Undefined Data Type",
                 }));
 

--- a/src/SharpBrick.PoweredUp/Protocol/Messages/PortValueData.cs
+++ b/src/SharpBrick.PoweredUp/Protocol/Messages/PortValueData.cs
@@ -1,6 +1,6 @@
 namespace SharpBrick.PoweredUp.Protocol.Messages
 {
     public record PortValueData(byte PortId, byte ModeIndex, PortModeInformationDataType DataType);
-    public record PortValueData<TPayload>(byte PortId, byte ModeIndex, PortModeInformationDataType DataType, TPayload[] InputValues, TPayload[] SIInputValues, TPayload[] PctInputValues)
+    public record PortValueData<TDatasetType, TOutputType>(byte PortId, byte ModeIndex, PortModeInformationDataType DataType, TDatasetType[] InputValues, TOutputType[] SIInputValues, TOutputType[] PctInputValues)
         : PortValueData(PortId, ModeIndex, DataType);
 }

--- a/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueCombinedModeEncoderTest.cs
+++ b/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueCombinedModeEncoderTest.cs
@@ -46,15 +46,15 @@ namespace SharpBrick.PoweredUp.Protocol.Formatter
                 Assert.Equal(expectedDataType[pos], portValueData.DataType);
                 Assert.Equal(expectedDataType[pos], portValueData.DataType);
 
-                if (portValueData is PortValueData<sbyte> actual)
+                if (portValueData is PortValueData<sbyte, sbyte> actual)
                 {
                     Assert.Equal(expectedData[pos], actual.InputValues[0]);
                 }
-                if (portValueData is PortValueData<short> actual2)
+                if (portValueData is PortValueData<short, short> actual2)
                 {
                     Assert.Equal(expectedData[pos], actual2.InputValues[0]);
                 }
-                if (portValueData is PortValueData<int> actual3)
+                if (portValueData is PortValueData<int, int> actual3)
                 {
                     Assert.Equal(expectedData[pos], actual3.InputValues[0]);
                 }

--- a/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueEncoderTest.cs
+++ b/test/SharpBrick.PoweredUp.Test/Protocol/Formatter/PortValueEncoderTest.cs
@@ -14,9 +14,9 @@ namespace SharpBrick.PoweredUp.Protocol.Formatter
         [Theory]
         [InlineData("0A-00-45-63-21-00-F9-FF-FD-FF", 0x63, PortModeInformationDataType.Int16, new short[] { 33, -7, -3 })]
         public void PortValueSingleEncoder_Decode_Short(string dataAsString, byte expectedPortId, PortModeInformationDataType expectedDataType, short[] expectedData)
-            => PortValueSingleEncoder_Decode<short>(dataAsString, expectedPortId, expectedDataType, expectedData);
+            => PortValueSingleEncoder_Decode<short, short>(dataAsString, expectedPortId, expectedDataType, expectedData);
 
-        private void PortValueSingleEncoder_Decode<T>(string dataAsString, byte expectedPortId, PortModeInformationDataType expectedDataType, T[] expectedData)
+        private void PortValueSingleEncoder_Decode<TDatasetType, TOutputType>(string dataAsString, byte expectedPortId, PortModeInformationDataType expectedDataType, TDatasetType[] expectedData)
         {
             var knowledge = new ProtocolKnowledge();
 
@@ -40,9 +40,9 @@ namespace SharpBrick.PoweredUp.Protocol.Formatter
                     Assert.Equal(d.PortId, expectedPortId);
                     Assert.Equal(d.DataType, expectedDataType);
 
-                    if (d is PortValueData<T> actual)
+                    if (d is PortValueData<TDatasetType, TOutputType> actual)
                     {
-                        Assert.Collection(actual.InputValues, expectedData.Cast<T>().Select<T, Action<T>>(expected => actual => Assert.Equal(expected, actual)).ToArray());
+                        Assert.Collection(actual.InputValues, expectedData.Cast<TDatasetType>().Select<TDatasetType, Action<TDatasetType>>(expected => actual => Assert.Equal(expected, actual)).ToArray());
                     }
                 }
             );


### PR DESCRIPTION
- Reorganized decoder (PortValueSingleEncoder)
- Reorganized Single/MultiValueMode infrastructure of devices
- Re-aligned all devices to new TOutputType
- No Testing yet
- No override to double for any port mode

#126 breaking