### PR TITLE
Add Plugin Support to dynamically load BLE Adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -431,6 +431,10 @@ $RECYCLE.BIN/
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+src/SharpBrick.PoweredUp.Cli/plugins
+examples/SharpBrick.PoweredUp.Examples/plugins
+
 /src/SharpBrick.PoweredUp.BlueGigaBLE/.editorconfig
 /examples/SharpBrick.PoweredUp.Examples/Properties/launchSettings.json
 src/SharpBrick.PoweredUp.Cli/Properties/launchSettings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/examples/SharpBrick.PoweredUp.Examples/bin/Debug/netcoreapp3.1/SharpBrick.PoweredUp.Examples.dll",
+            "program": "${workspaceFolder}/examples/SharpBrick.PoweredUp.Examples/bin/Debug/net5.0/SharpBrick.PoweredUp.Examples.dll",
             "args": [
                 "--trace"
             ],
@@ -22,7 +22,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/SharpBrick.PoweredUp.Cli/bin/Debug/netcoreapp3.1/SharpBrick.PoweredUp.Cli.dll",
+            "program": "${workspaceFolder}/src/SharpBrick.PoweredUp.Cli/bin/Debug/net5.0/SharpBrick.PoweredUp.Cli.dll",
             "args": [
                 "device",
                 "list"
@@ -36,7 +36,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/SharpBrick.PoweredUp.Cli/bin/Debug/netcoreapp3.1/SharpBrick.PoweredUp.Cli.dll",
+            "program": "${workspaceFolder}/src/SharpBrick.PoweredUp.Cli/bin/Debug/net5.0/SharpBrick.PoweredUp.Cli.dll",
             "args": [
                 "device",
                 "dump-static-port",
@@ -52,7 +52,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceFolder}/src/SharpBrick.PoweredUp.Cli/bin/Debug/netcoreapp3.1/SharpBrick.PoweredUp.Cli.dll",
+            "program": "${workspaceFolder}/src/SharpBrick.PoweredUp.Cli/bin/Debug/net5.0/SharpBrick.PoweredUp.Cli.dll",
             "args": [
                 "device",
                 "pretty-print",

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleTwoHubsMotorControl.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleTwoHubsMotorControl.cs
@@ -2,7 +2,6 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using SharpBrick.PoweredUp;
-using SharpBrick.PoweredUp.BlueGigaBLE;
 
 namespace Example
 {

--- a/examples/SharpBrick.PoweredUp.Examples/Program.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/Program.cs
@@ -13,6 +13,7 @@ namespace SharpBrick.PoweredUp.Examples
         {
             // load a configuration object to be used when dynamically loading bluetooth adapters
             var configuration = new ConfigurationBuilder()
+                .SetBasePath(Environment.CurrentDirectory)
                 .AddJsonFile("poweredup.json", true)
                 .AddCommandLine(args)
                 .Build();

--- a/examples/SharpBrick.PoweredUp.Examples/SharpBrick.PoweredUp.Examples.csproj
+++ b/examples/SharpBrick.PoweredUp.Examples/SharpBrick.PoweredUp.Examples.csproj
@@ -2,17 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\SharpBrick.PoweredUp.BlueGigaBLE\SharpBrick.PoweredUp.BlueGigaBLE.csproj" />
     <ProjectReference Include="..\..\src\SharpBrick.PoweredUp\SharpBrick.PoweredUp.csproj" />
-    <ProjectReference Include="..\..\src\SharpBrick.PoweredUp.WinRT\SharpBrick.PoweredUp.WinRT.csproj" />
+    <ProjectReference Include="..\..\src\SharpBrick.PoweredUp.CliBase\SharpBrick.PoweredUp.CliBase.csproj" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />

--- a/powered-up.sln
+++ b/powered-up.sln
@@ -24,6 +24,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SharpBrick.PoweredUp.BlueGi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpBrick.PoweredUp.TestScript", "test\SharpBrick.PoweredUp.TestScript\SharpBrick.PoweredUp.TestScript.csproj", "{2A100817-6E86-4E58-8183-0EA7F49C0848}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpBrick.PoweredUp.CliBase", "src\SharpBrick.PoweredUp.CliBase\SharpBrick.PoweredUp.CliBase.csproj", "{20F8B348-4855-4522-A00D-1EB4386C2EBC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,18 @@ Global
 		{2A100817-6E86-4E58-8183-0EA7F49C0848}.Release|x64.Build.0 = Release|Any CPU
 		{2A100817-6E86-4E58-8183-0EA7F49C0848}.Release|x86.ActiveCfg = Release|Any CPU
 		{2A100817-6E86-4E58-8183-0EA7F49C0848}.Release|x86.Build.0 = Release|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Debug|x64.Build.0 = Debug|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Debug|x86.Build.0 = Debug|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Release|x64.ActiveCfg = Release|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Release|x64.Build.0 = Release|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Release|x86.ActiveCfg = Release|Any CPU
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -143,6 +157,7 @@ Global
 		{F66A2B09-84B6-477D-9B15-926E771C7D80} = {62C31C3D-8ACF-4ED3-A3D8-225536F3AC6D}
 		{E0DC0096-D7F1-4995-833D-9A6C0C3F8F98} = {62C31C3D-8ACF-4ED3-A3D8-225536F3AC6D}
 		{2A100817-6E86-4E58-8183-0EA7F49C0848} = {39B30145-497F-4AEB-A014-BBF27DA0651A}
+		{20F8B348-4855-4522-A00D-1EB4386C2EBC} = {62C31C3D-8ACF-4ED3-A3D8-225536F3AC6D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {34AA1641-ACED-43ED-A0DD-BA88E43A67A8}

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaAsPluginStartup.cs
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaAsPluginStartup.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SharpBrick.PoweredUp.BlueGigaBLE
+{
+    public class BlueGigaAsPluginStartup : IPluginStartup
+    {
+        public void Configure(IServiceCollection services, IConfiguration configuration)
+        {
+            services
+                .AddBlueGigaBLEBluetooth(options =>
+                {
+                    configuration.Bind(options);
+                });
+        }
+    }
+}

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/SharpBrick.PoweredUp.BlueGigaBLE.csproj
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/SharpBrick.PoweredUp.BlueGigaBLE.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
   
     <PackageReference Include="BGLibExt" Version="2.0.1" />
-    <PackageReference Include="System.IO.Ports" Version="5.0.0" />
+    <PackageReference Include="System.IO.Ports" Version="5.0.1" />
 
 
     <!-- Assemblies already loaded by hosting application (and used in interface or shared DI container) -->

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/SharpBrick.PoweredUp.BlueGigaBLE.csproj
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/SharpBrick.PoweredUp.BlueGigaBLE.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
@@ -10,17 +10,32 @@
   <PropertyGroup>
     <LangVersion>9.0</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Remove="BGLib.cs" />
-    <Compile Remove="BGLibExtExtensions.cs" />
-  </ItemGroup>
 
   <ItemGroup>
+  
     <PackageReference Include="BGLibExt" Version="2.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="System.IO.Ports" Version="5.0.0" />
+
+
+    <!-- Assemblies already loaded by hosting application (and used in interface or shared DI container) -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0">
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0">
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0">
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <!-- explicitely referenced to supress copy from BGLibExt -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0">
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/SharpBrick.PoweredUp.BlueGigaBLE.csproj
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/SharpBrick.PoweredUp.BlueGigaBLE.csproj
@@ -18,12 +18,20 @@
   <ItemGroup>
     <PackageReference Include="BGLibExt" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="5.0.0" />
     <PackageReference Include="System.IO.Ports" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SharpBrick.PoweredUp\SharpBrick.PoweredUp.csproj" />
+    <ProjectReference Include="..\SharpBrick.PoweredUp\SharpBrick.PoweredUp.csproj" >
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\SharpBrick.PoweredUp.CliBase\SharpBrick.PoweredUp.CliBase.csproj" >
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/src/SharpBrick.PoweredUp.Cli/Program.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Program.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using McMaster.Extensions.CommandLineUtils;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using SharpBrick.PoweredUp.Bluetooth;
 using SharpBrick.PoweredUp.Functions;
 
@@ -22,12 +22,24 @@ namespace SharpBrick.PoweredUp.Cli
 
         static async Task<int> Main(string[] args)
         {
+            // load a configuration object to be used when dynamically loading bluetooth adapters
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("poweredup.json", true)
+                .AddCommandLine(args)
+                .Build();
+
+            bool enableTrace = bool.TryParse(configuration["EnableTrace"], out var enableTraceInConfig) && enableTraceInConfig;
+
             var app = new CommandLineApplication
             {
                 Name = "poweredup",
                 Description = "A command line interface to investigate LEGO Powered UP hubs and devices.",
                 UnrecognizedArgumentHandling = UnrecognizedArgumentHandling.CollectAndContinue,
             };
+
+            // pseudo options. will be handled via DI Container initialization.
+            app.Option("--EnableTrace", "Enable Tracing (default: no trace)", CommandOptionType.NoValue);
+            app.Option("--BluetoothAdapter", "Use a specified BLE adapter (e.g. WinRT or BlueGigaBLE). Defaults to WinRT. Some adapter might require additional parameters.", CommandOptionType.SingleValue);
 
             app.HelpOption();
             app.OnExecute(() =>
@@ -51,18 +63,12 @@ namespace SharpBrick.PoweredUp.Cli
                 {
                     deviceListApp.Description = "Inspect all devices declared on the Hub by using information gathered using the LEGO Wireless Protocol";
                     deviceListApp.HelpOption();
-                    var traceOption = deviceListApp.Option("--trace", "Enable Tracing (default: no trace)", CommandOptionType.NoValue);
-                    var blueGigaOption = deviceListApp.Option("--usebluegiga", "Use BlueGiga-Bluetooth adapter-stack (default is WindowsRT-Bluetooth-Stack) and give the port (for example 'COM4') as parameter", CommandOptionType.SingleValue);
-                    var traceBlueGigaOption = deviceListApp.Option("--tracebluegiga", "Emmit extra trace from Bluegiga-communication (default: no extra trace)", CommandOptionType.NoValue);
                     deviceListApp.OnExecuteAsync(async cts =>
                     {
                         try
                         {
                             //for a boolean parameter it is just enough to test wether it has been given at all; HasValue() is true, if the parameter has been given:
-                            var enableTrace = traceOption.HasValue();
-                            var bluetoothStackPort = blueGigaOption.HasValue() ? blueGigaOption.Value() : "WINRT";
-                            var enableBlueGigaTrace = traceBlueGigaOption.HasValue();
-                            var serviceProvider = CreateServiceProvider(enableTrace, bluetoothStackPort, enableBlueGigaTrace);
+                            var serviceProvider = CreateServiceProvider(configuration);
                             (ulong bluetoothAddress, SystemType systemType) = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
 
                             if (bluetoothAddress == 0)
@@ -96,25 +102,17 @@ namespace SharpBrick.PoweredUp.Cli
                 {
                     deviceDumpStaticPortApp.Description = "Inspect a specific device on a Hub Port by using (non-dynamic) information gathered using the LEGO Wireless Protocol. Emits a binary dump (use list for human readable output).";
                     deviceDumpStaticPortApp.HelpOption();
-                    var traceOption = deviceDumpStaticPortApp.Option("--trace", "Enable Tracing (default: no trace)", CommandOptionType.NoValue);
-                    var blueGigaOption = deviceDumpStaticPortApp.Option("--usebluegiga", "Use BlueGiga-Bluetooth adapter-stack (default is WindowsRT-Bluetooth-Stack) and give the port (for example 'COM4') as parameter", CommandOptionType.SingleValue);
-                    var traceBlueGigaOption = deviceDumpStaticPortApp.Option("--tracebluegiga", "Emmit extra trace from Bluegiga-communication", CommandOptionType.NoValue);
-
 
                     var portOption = deviceDumpStaticPortApp.Option("-p", "Port to Dump", CommandOptionType.SingleValue);
                     var headerOption = deviceDumpStaticPortApp.Option("-f", "Add Hub and IOType Header", CommandOptionType.NoValue);
-                    
+
                     deviceDumpStaticPortApp.OnExecuteAsync(async cts =>
                     {
                         try
                         {
-
-                            var enableTrace = traceOption.HasValue();
                             var headerEnabled = headerOption.Values.Count > 0;
-                            var bluetoothStackPort = blueGigaOption.HasValue() ? blueGigaOption.Value() : "WINRT";
-                            var enableBlueGigaTrace = traceBlueGigaOption.HasValue();
 
-                            var serviceProvider = CreateServiceProvider(enableTrace, bluetoothStackPort, enableBlueGigaTrace);
+                            var serviceProvider = CreateServiceProvider(configuration);
                             (ulong bluetoothAddress, SystemType systemType) = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
 
                             if (bluetoothAddress == 0)
@@ -151,7 +149,6 @@ namespace SharpBrick.PoweredUp.Cli
                 {
                     prettyPrintApp.Description = "Pretty prints a previously recorded binary dump collected using dump-static-ports";
                     prettyPrintApp.HelpOption();
-                    var traceOption = prettyPrintApp.Option("--trace", "Enable Tracing (default: no trace) ", CommandOptionType.NoValue);
                     var systemTypeOption = prettyPrintApp.Option("--t", "System Type (parsable number)", CommandOptionType.SingleValue);
                     var hubOption = prettyPrintApp.Option("--h", "Hub Id (decimal number)", CommandOptionType.SingleValue);
                     var portOption = prettyPrintApp.Option("--p", "Port Id (decimal number)", CommandOptionType.SingleValue);
@@ -164,7 +161,6 @@ namespace SharpBrick.PoweredUp.Cli
                     {
                         try
                         {
-                            var enableTrace = traceOption.HasValue();
                             var systemType = byte.TryParse(systemTypeOption.Value(), out var x1) ? x1 : (byte)0;
                             var hubId = byte.TryParse(hubOption.Value(), out var x2) ? x2 : (byte)0;
                             var portId = byte.TryParse(portOption.Value(), out var x3) ? x3 : (byte)0;
@@ -173,7 +169,7 @@ namespace SharpBrick.PoweredUp.Cli
                             var swVersion = Version.TryParse(swVersionOption.Value(), out var x6) ? x6 : new Version("0.0.0.0");
                             var file = fileOption.Value();
 
-                            var serviceProvider = CreateServiceProviderWithMock(enableTrace);
+                            var serviceProvider = CreateServiceProviderWithMock(configuration);
 
                             using (var scope = serviceProvider.CreateScope())
                             {
@@ -209,48 +205,24 @@ namespace SharpBrick.PoweredUp.Cli
             return await app.ExecuteAsync(args);
         }
 
-        private static IServiceCollection CreateServiceProviderInternal(bool enableTrace)
+        private static IServiceCollection CreateServiceProviderInternal(IConfiguration configuration)
             => new ServiceCollection()
-                .AddLogging(builder =>
-                {
-                    builder.ClearProviders();
-
-                    if (enableTrace)
-                    {
-                        builder.AddConsole();
-
-                        builder.AddFilter("SharpBrick.PoweredUp.Bluetooth.BluetoothKernel", LogLevel.Debug);
-                        builder.AddFilter("SharpBrick.PoweredUp.BlueGigaBLE.BlueGigaBLEPoweredUpBluetoothAdapater", LogLevel.Debug);
-                    }
-                })
                 .AddPoweredUp()
+                .AddPoweredUpConsoleLogging(configuration)
 
                 // Add CLI Commands
                 .AddTransient<DumpStaticPortInfo>()
                 .AddTransient<DevicesList>()
                 .AddTransient<PrettyPrint>();
-        private static IServiceProvider CreateServiceProviderWithMock(bool enableTrace)
-            => CreateServiceProviderInternal(enableTrace)
+        private static IServiceProvider CreateServiceProviderWithMock(IConfiguration configuration)
+            => CreateServiceProviderInternal(configuration)
                 .AddMockBluetooth()
                 .BuildServiceProvider();
-        private static IServiceProvider CreateServiceProvider(bool enableTrace, string bluetoothStackPort = "WINRT", bool enableBlueGigaTrace=false)
-        {
-            var serviceCollection = CreateServiceProviderInternal(enableTrace);
-            if (bluetoothStackPort.Equals("WINRT", StringComparison.OrdinalIgnoreCase))
-            {
 
-                serviceCollection.AddWinRTBluetooth();
-            } 
-            else
-            {
-                serviceCollection.AddBlueGigaBLEBluetooth(options =>
-                {
-                    options.COMPortName = bluetoothStackPort;
-                    options.TraceDebug = enableBlueGigaTrace;
-                });
-            }
-            return serviceCollection.BuildServiceProvider();
-        }
+        private static IServiceProvider CreateServiceProvider(IConfiguration configuration)
+            => CreateServiceProviderInternal(configuration)
+                .AddPoweredUpBluetooth(configuration)
+                .BuildServiceProvider();
 
         public static async Task AddTraceWriterAsync(IServiceProvider serviceProvider, bool enableTrace)
         {

--- a/src/SharpBrick.PoweredUp.Cli/SharpBrick.PoweredUp.Cli.csproj
+++ b/src/SharpBrick.PoweredUp.Cli/SharpBrick.PoweredUp.Cli.csproj
@@ -2,21 +2,23 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>poweredup</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SharpBrick.PoweredUp.BlueGigaBLE\SharpBrick.PoweredUp.BlueGigaBLE.csproj" />
+    <ProjectReference Include="..\SharpBrick.PoweredUp.CliBase\SharpBrick.PoweredUp.CliBase.csproj" />
     <ProjectReference Include="..\SharpBrick.PoweredUp\SharpBrick.PoweredUp.csproj" />
-    <ProjectReference Include="..\SharpBrick.PoweredUp.WinRT\SharpBrick.PoweredUp.WinRT.csproj" />
   </ItemGroup>
 
-    <ItemGroup>
+
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/SharpBrick.PoweredUp.CliBase/Plugins/IPluginStartup.cs
+++ b/src/SharpBrick.PoweredUp.CliBase/Plugins/IPluginStartup.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SharpBrick.PoweredUp
+{
+    public interface IPluginStartup
+    {
+        void Configure(IServiceCollection services, IConfiguration configuration);
+    }
+}

--- a/src/SharpBrick.PoweredUp.CliBase/Plugins/PluginLoadContext.cs
+++ b/src/SharpBrick.PoweredUp.CliBase/Plugins/PluginLoadContext.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace SharpBrick.PoweredUp
+{
+    public class PluginLoadContext : AssemblyLoadContext
+    {
+        private AssemblyDependencyResolver _resolver;
+
+        public PluginLoadContext(string pluginPath)
+        {
+            _resolver = new AssemblyDependencyResolver(pluginPath);
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            string assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+            if (assemblyPath != null)
+            {
+                return LoadFromAssemblyPath(assemblyPath);
+            }
+
+            return null;
+        }
+
+        protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+        {
+            string libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+            if (libraryPath != null)
+            {
+                return LoadUnmanagedDllFromPath(libraryPath);
+            }
+
+            return IntPtr.Zero;
+        }
+    }
+}

--- a/src/SharpBrick.PoweredUp.CliBase/Plugins/ServiceCollectionExtensionsForLogging.cs
+++ b/src/SharpBrick.PoweredUp.CliBase/Plugins/ServiceCollectionExtensionsForLogging.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace SharpBrick.PoweredUp
+{
+    public static class ServiceCollectionExtensionsForLogging
+    {
+        public static IServiceCollection AddPoweredUpConsoleLogging(this IServiceCollection self, IConfiguration configuration)
+            => self.AddLogging(builder =>
+               {
+                   builder.ClearProviders();
+
+                   if (bool.TryParse(configuration["EnableTrace"], out var enableTrace) && enableTrace)
+                   {
+                       builder.AddConsole();
+
+                       builder.AddFilter("SharpBrick.PoweredUp.Bluetooth.BluetoothKernel", LogLevel.Debug);
+                       builder.AddFilter("SharpBrick.PoweredUp.BlueGigaBLE.BlueGigaBLEPoweredUpBluetoothAdapater", LogLevel.Debug);
+                   }
+               });
+    }
+}

--- a/src/SharpBrick.PoweredUp.CliBase/Plugins/ServiceCollectionExtensionsForPlugins.cs
+++ b/src/SharpBrick.PoweredUp.CliBase/Plugins/ServiceCollectionExtensionsForPlugins.cs
@@ -10,7 +10,6 @@ namespace SharpBrick.PoweredUp
     {
         public const string BluetoothAdapterConfigKey = "BluetoothAdapter";
         public const string DefaultBluetoothAdapter = "WinRT";
-        public const string BluetoothConfigConfigKey = "BluetoothConfig";
 
         public static IServiceCollection AddPoweredUpBluetooth(this IServiceCollection self, IConfiguration configuration)
         {

--- a/src/SharpBrick.PoweredUp.CliBase/Plugins/ServiceCollectionExtensionsForPlugins.cs
+++ b/src/SharpBrick.PoweredUp.CliBase/Plugins/ServiceCollectionExtensionsForPlugins.cs
@@ -1,0 +1,43 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SharpBrick.PoweredUp
+{
+    public static class ServiceCollectionExtensionsForPlugins
+    {
+        public const string BluetoothAdapterConfigKey = "BluetoothAdapter";
+        public const string DefaultBluetoothAdapter = "WinRT";
+        public const string BluetoothConfigConfigKey = "BluetoothConfig";
+
+        public static IServiceCollection AddPoweredUpBluetooth(this IServiceCollection self, IConfiguration configuration)
+        {
+            var bleAdapter = configuration[BluetoothAdapterConfigKey] ?? DefaultBluetoothAdapter;
+
+            var path = Path.Combine(Environment.CurrentDirectory, $"plugins", $"ble-{bleAdapter}", $"SharpBrick.PoweredUp.{bleAdapter}.dll");
+
+            return AddPoweredUpPlugin(self, configuration, path);
+        }
+
+        public static IServiceCollection AddPoweredUpPlugin(IServiceCollection self, IConfiguration configuration, string path)
+        {
+            var loadContext = new PluginLoadContext(Path.GetFullPath(path));
+
+            var assembly = loadContext.LoadFromAssemblyPath(path);
+
+            foreach (var t in assembly.GetTypes())
+            {
+                if (t.GetInterfaces().Any(it => it == typeof(IPluginStartup)))
+                {
+                    var pluginStartup = Activator.CreateInstance(t) as IPluginStartup;
+
+                    pluginStartup.Configure(self, configuration);
+                }
+            }
+
+            return self;
+        }
+    }
+}

--- a/src/SharpBrick.PoweredUp.CliBase/SharpBrick.PoweredUp.CliBase.csproj
+++ b/src/SharpBrick.PoweredUp.CliBase/SharpBrick.PoweredUp.CliBase.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\SharpBrick.PoweredUp\SharpBrick.PoweredUp.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/SharpBrick.PoweredUp.WinRT/SharpBrick.PoweredUp.WinRT.csproj
+++ b/src/SharpBrick.PoweredUp.WinRT/SharpBrick.PoweredUp.WinRT.csproj
@@ -5,7 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SharpBrick.PoweredUp\SharpBrick.PoweredUp.csproj" />
+    <ProjectReference Include="..\SharpBrick.PoweredUp\SharpBrick.PoweredUp.csproj" >
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\SharpBrick.PoweredUp.CliBase\SharpBrick.PoweredUp.CliBase.csproj" >
+        <Private>false</Private>
+        <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/src/SharpBrick.PoweredUp.WinRT/WinRTAsPluginStartup.cs
+++ b/src/SharpBrick.PoweredUp.WinRT/WinRTAsPluginStartup.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace SharpBrick.PoweredUp.WinRT
+{
+    public class WinRTAsPluginStartup : IPluginStartup
+    {
+        public void Configure(IServiceCollection services, IConfiguration configuration)
+            => services.AddWinRTBluetooth();
+    }
+}

--- a/test/SharpBrick.PoweredUp.Test/SharpBrick.PoweredUp.Test.csproj
+++ b/test/SharpBrick.PoweredUp.Test/SharpBrick.PoweredUp.Test.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="coverlet.collector" Version="3.0.3" />


### PR DESCRIPTION
- Enable usage of Configuration JSON file / command line input
- Add Plugin Infrastructure for BLE adapters for CLIs
- Enable VS Code Debugger to run .NET 5 builds
- Add CliBase project to unify DI container creation for CLI projects
- Rewrote SharpBrick.PoweredUp.WinRT/BlueGigaBLE into plugins and
  dereference from Examples and CLI
- Add selection by command line of execute example

Closes #155 non-breaking