### PR TITLE
Change how BluetoothAdapter identifies devices

### DIFF
--- a/examples/SharpBrick.PoweredUp.Examples/ExampleBluetoothByKnownAddress.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleBluetoothByKnownAddress.cs
@@ -11,7 +11,7 @@ namespace Example
         // device needs to be switched on!
         public override async Task DiscoverAsync(bool enableTrace)
         {
-            var hub = Host.Create<TechnicMediumHub>(ChangeMe_BluetoothAddress);
+            var hub = await Host.CreateByStateAsync<TechnicMediumHub>(ChangeMe_BluetoothAddress);
 
             SelectedHub = DirectlyConnectedHub = hub;
 

--- a/examples/SharpBrick.PoweredUp.Examples/ExampleTwoHubsMotorControl.cs
+++ b/examples/SharpBrick.PoweredUp.Examples/ExampleTwoHubsMotorControl.cs
@@ -19,8 +19,8 @@ namespace Example
         // devices need to be switched on!
         public override async Task DiscoverAsync(bool enableTrace)
         {
-            var hub1 = Host.Create<TechnicMediumHub>(BluetoothAddressHub1);
-            var hub2 = Host.Create<TwoPortHub>(BluetoothAddressHub2);
+            var hub1 = await Host.CreateByStateAsync<TechnicMediumHub>(BluetoothAddressHub1);
+            var hub2 = await Host.CreateByStateAsync<TwoPortHub>(BluetoothAddressHub2);
             Log.LogInformation($"Press button on first Hub with address {BluetoothAddressHub1}");
             await hub1.ConnectAsync();
             Log.LogInformation($"Press button on second Hub with address {BluetoothAddressHub2}");

--- a/src/SharpBrick.PoweredUp.Cli/Program.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Program.cs
@@ -296,7 +296,7 @@ namespace SharpBrick.PoweredUp.Cli
                     var deviceType = (PoweredUpHubManufacturerData)info.ManufacturerData[1];
                     devices.Add((idx, info, deviceType));
 
-                    var text = (info is IPoweredUpBluetoothDeviceInfoWithMacAddress mac) ? mac.MacAddress[0].ToString() : "not revealed";
+                    var text = (info is IPoweredUpBluetoothDeviceInfoWithMacAddress mac) ? mac.ToIdentificationString() : "not revealed";
 
                     Console.WriteLine($"{idx}: {(PoweredUpHubManufacturerData)info.ManufacturerData[1]} (with address {text})");
 

--- a/src/SharpBrick.PoweredUp.Cli/Program.cs
+++ b/src/SharpBrick.PoweredUp.Cli/Program.cs
@@ -72,10 +72,12 @@ namespace SharpBrick.PoweredUp.Cli
                         try
                         {
                             var serviceProvider = CreateServiceProvider(configuration);
-                            (ulong bluetoothAddress, SystemType systemType) = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
+                            var (bluetoothDeviceInfo, systemType) = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
 
-                            if (bluetoothAddress == 0)
+                            if (bluetoothDeviceInfo == null)
+                            {
                                 return Program.BluetoothNoSelectedDeviceExitCode;
+                            }
 
                             // initialize a DI scope per bluetooth connection / protocol (e.g. protocol is a per-bluetooth connection service)
                             using (var scope = serviceProvider.CreateScope())
@@ -84,7 +86,7 @@ namespace SharpBrick.PoweredUp.Cli
 
                                 await AddTraceWriterAsync(scopedServiceProvider, enableTrace);
 
-                                scopedServiceProvider.GetService<BluetoothKernel>().BluetoothAddress = bluetoothAddress;
+                                scopedServiceProvider.GetService<BluetoothKernel>().BluetoothDeviceInfo = bluetoothDeviceInfo;
 
                                 var deviceListCli = scopedServiceProvider.GetService<DevicesList>(); // ServiceLocator ok: transient factory
 
@@ -122,10 +124,12 @@ namespace SharpBrick.PoweredUp.Cli
                             var headerEnabled = headerOption.Values.Count > 0;
 
                             var serviceProvider = CreateServiceProvider(configuration);
-                            (ulong bluetoothAddress, SystemType systemType) = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
+                            var (bluetoothDeviceInfo, systemType) = FindAndSelectHub(serviceProvider.GetService<IPoweredUpBluetoothAdapter>());
 
-                            if (bluetoothAddress == 0)
+                            if (bluetoothDeviceInfo == null)
+                            {
                                 return Program.BluetoothNoSelectedDeviceExitCode;
+                            }
 
                             // initialize a DI scope per bluetooth connection / protocol (e.g. protocol is a per-bluetooth connection service)
                             using (var scope = serviceProvider.CreateScope())
@@ -134,7 +138,7 @@ namespace SharpBrick.PoweredUp.Cli
 
                                 await AddTraceWriterAsync(scopedServiceProvider, enableTrace);
 
-                                scopedServiceProvider.GetService<BluetoothKernel>().BluetoothAddress = bluetoothAddress;
+                                scopedServiceProvider.GetService<BluetoothKernel>().BluetoothDeviceInfo = bluetoothDeviceInfo;
 
                                 var dumpStaticPortInfoCommand = scopedServiceProvider.GetService<DumpStaticPortInfo>(); // ServiceLocator ok: transient factory
 
@@ -275,11 +279,11 @@ namespace SharpBrick.PoweredUp.Cli
             }
         }
 
-        private static (ulong bluetoothAddress, SystemType systemType) FindAndSelectHub(IPoweredUpBluetoothAdapter poweredUpBluetoothAdapter)
+        private static (IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo, SystemType systemType) FindAndSelectHub(IPoweredUpBluetoothAdapter poweredUpBluetoothAdapter)
         {
-            ulong resultBluetooth = 0;
+            IPoweredUpBluetoothDeviceInfo resultDeviceInfo = default;
             SystemType resultSystemType = default;
-            var devices = new ConcurrentBag<(int key, ulong bluetoothAddresss, PoweredUpHubManufacturerData deviceType)>();
+            var devices = new ConcurrentBag<(int key, IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo, PoweredUpHubManufacturerData deviceType)>();
             var cts = new CancellationTokenSource();
             int idx = 1;
 
@@ -287,12 +291,14 @@ namespace SharpBrick.PoweredUp.Cli
 
             poweredUpBluetoothAdapter.Discover(info =>
             {
-                if (devices.FirstOrDefault(kv => kv.bluetoothAddresss == info.BluetoothAddress) == default)
+                if (devices.FirstOrDefault(kv => kv.bluetoothDeviceInfo.Equals(info)) == default)
                 {
                     var deviceType = (PoweredUpHubManufacturerData)info.ManufacturerData[1];
-                    devices.Add((idx, info.BluetoothAddress, deviceType));
+                    devices.Add((idx, info, deviceType));
 
-                    Console.WriteLine($"{idx}: {(PoweredUpHubManufacturerData)info.ManufacturerData[1]} (with address {info.BluetoothAddress})");
+                    var text = (info is IPoweredUpBluetoothDeviceInfoWithMacAddress mac) ? mac.MacAddress[0].ToString() : "not revealed";
+
+                    Console.WriteLine($"{idx}: {(PoweredUpHubManufacturerData)info.ManufacturerData[1]} (with address {text})");
 
                     idx++;
                 }
@@ -309,16 +315,16 @@ namespace SharpBrick.PoweredUp.Cli
             {
                 var selected = devices.FirstOrDefault(kv => kv.key == key);
 
-                resultBluetooth = selected.bluetoothAddresss; // default is 0
+                resultDeviceInfo = selected.bluetoothDeviceInfo;
                 resultSystemType = (SystemType)selected.deviceType;
 
-                if (resultBluetooth != default)
+                if (resultDeviceInfo != default)
                 {
                     Console.WriteLine($"Selected {selected.deviceType} with key {selected.key}");
                 }
             }
 
-            return (resultBluetooth, resultSystemType);
+            return (resultDeviceInfo, resultSystemType);
         }
     }
 }

--- a/src/SharpBrick.PoweredUp.Mobile/NativeDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/NativeDeviceInfo.cs
@@ -2,8 +2,10 @@
 {
     public class NativeDeviceInfo
     {
-        public string MacAddress { get; set; }
-
-        public ulong MacAddressNumeric { get; set; }
+        /// <summary>
+        /// In Android, the MacAddressString will be returned
+        /// In iOS the unique identifier is used
+        /// </summary>
+        public string DeviceIdentifier { get; set; }
     }
 }

--- a/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
@@ -1,28 +1,69 @@
 using System;
+using System.Runtime.InteropServices;
 using SharpBrick.PoweredUp.Bluetooth;
+using SharpBrick.PoweredUp.Utils;
 
 namespace SharpBrick.PoweredUp.Mobile
 {
     public class XamarinBluetoothDeviceInfo : IPoweredUpBluetoothDeviceInfo, IPoweredUpBluetoothDeviceInfoWithMacAddress
     {
+        private string _deviceIdentifier;
+
+        public string DeviceIdentifier
+        {
+            get => _deviceIdentifier;
+            set
+            {
+                _deviceIdentifier = value;
+                UpdateMacAddress();
+            }
+        }
+
         public string Name { get; set; }
+        
         public byte[] ManufacturerData { get; set; }
 
-        public byte[] MacAddress => throw new NotImplementedException();
+        public byte[] MacAddress { get; private set; } = new byte[0];
 
-        public ulong MacAddressAsUInt64 { get; set; }
+        public ulong MacAddressAsUInt64 { get; private set; } = 0;
 
         public bool Equals(IPoweredUpBluetoothDeviceInfo other)
         {
             if (other != null && other is XamarinBluetoothDeviceInfo otherXamarin)
             {
-                return this.MacAddressAsUInt64 == otherXamarin.MacAddressAsUInt64;
+                return this.DeviceIdentifier == otherXamarin.DeviceIdentifier;
             }
             else
             {
                 return false;
             }
         }
+
+        private void UpdateMacAddress()
+        {
+            if (string.IsNullOrWhiteSpace(_deviceIdentifier)) return;
+
+            if (Guid.TryParse(_deviceIdentifier, out Guid result))
+            {
+                // we're on an iOS device -> no mac address is revealed
+                return;
+            }
+
+            if (_deviceIdentifier.Contains(":"))
+            {
+                MacAddress = BytesStringUtil.HexStringToByteArray(_deviceIdentifier);
+                MacAddressAsUInt64 = BytesStringUtil.HexStringToUInt64(_deviceIdentifier);
+                return;
+            }
+
+            if (ulong.TryParse(_deviceIdentifier, out ulong macAdressAsUlong))
+            {
+                MacAddressAsUInt64 = macAdressAsUlong;
+                MacAddress = BytesStringUtil.UInt64MacAddressToByteArray(macAdressAsUlong);
+                _deviceIdentifier = BytesStringUtil.ByteArrayToHexString(MacAddress);
+            }
+        }
+        
     }
 
 }

--- a/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
@@ -1,0 +1,28 @@
+using System;
+using SharpBrick.PoweredUp.Bluetooth;
+
+namespace SharpBrick.PoweredUp.Mobile
+{
+    public class XamarinBluetoothDeviceInfo : IPoweredUpBluetoothDeviceInfo, IPoweredUpBluetoothDeviceInfoWithMacAddress
+    {
+        public string Name { get; set; }
+        public byte[] ManufacturerData { get; set; }
+
+        public byte[] MacAddress => throw new NotImplementedException();
+
+        public ulong MacAddressAsUInt64 { get; set; }
+
+        public bool Equals(IPoweredUpBluetoothDeviceInfo other)
+        {
+            if (other != null && other is XamarinBluetoothDeviceInfo otherXamarin)
+            {
+                return this.MacAddressAsUInt64 == otherXamarin.MacAddressAsUInt64;
+            }
+            else
+            {
+                return false;
+            }
+        }
+    }
+
+}

--- a/src/SharpBrick.PoweredUp.Mobile/XamarinPoweredUpBluetoothAdapter.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/XamarinPoweredUpBluetoothAdapter.cs
@@ -14,7 +14,7 @@ namespace SharpBrick.PoweredUp.Mobile
     {
         private readonly IAdapter _bluetoothAdapter;
         private readonly INativeDeviceInfoProvider _deviceInfoProvider;
-        private readonly Dictionary<ulong, IDevice> _discoveredDevices = new Dictionary<ulong, IDevice>();
+        private readonly Dictionary<string, IDevice> _discoveredDevices = new Dictionary<string, IDevice>();
 
         public XamarinPoweredUpBluetoothAdapter(IBluetoothLE bluetooth, INativeDeviceInfoProvider deviceInfoProvider)
         {
@@ -48,8 +48,10 @@ namespace SharpBrick.PoweredUp.Mobile
                     data.RemoveRange(0, 2);
                     info.ManufacturerData = data.ToArray();
 
+                    var nativeDeviceInfo = _deviceInfoProvider.GetNativeDeviceInfo(args.Device.NativeDevice);
+
                     info.Name = args.Device.Name;
-                    info.MacAddressAsUInt64 = _deviceInfoProvider.GetNativeDeviceInfo(args.Device.NativeDevice).MacAddressNumeric;
+                    info.DeviceIdentifier= nativeDeviceInfo.DeviceIdentifier;
 
                     AddInternalDevice(args.Device, info);
                     await discoveryHandler(info).ConfigureAwait(false);
@@ -59,13 +61,13 @@ namespace SharpBrick.PoweredUp.Mobile
 
         private void AddInternalDevice(IDevice device, XamarinBluetoothDeviceInfo info)
         {
-            if (!_discoveredDevices.ContainsKey(info.MacAddressAsUInt64))
+            if (!_discoveredDevices.ContainsKey(info.DeviceIdentifier))
             {
-                _discoveredDevices.Add(info.MacAddressAsUInt64, device);
+                _discoveredDevices.Add(info.DeviceIdentifier, device);
             }
             else
             {
-                _discoveredDevices[info.MacAddressAsUInt64] = device;
+                _discoveredDevices[info.DeviceIdentifier] = device;
             }
         }
 
@@ -92,9 +94,9 @@ namespace SharpBrick.PoweredUp.Mobile
 
         public async Task<IPoweredUpBluetoothDevice> GetDeviceAsync(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo)
         {
-            var bluetoothAddress = (bluetoothDeviceInfo is XamarinBluetoothDeviceInfo local) ? local.MacAddressAsUInt64 : throw new ArgumentException("DeviceInfo not created by adapter", nameof(bluetoothDeviceInfo));
+            var deviceId = (bluetoothDeviceInfo is XamarinBluetoothDeviceInfo local) ? local.DeviceIdentifier : throw new ArgumentException("DeviceInfo not created by adapter", nameof(bluetoothDeviceInfo));
 
-            if (!_discoveredDevices.ContainsKey(bluetoothAddress))
+            if (!_discoveredDevices.ContainsKey(deviceId))
             {
                 CancellationTokenSource cts = new CancellationTokenSource(10000);
 
@@ -111,19 +113,20 @@ namespace SharpBrick.PoweredUp.Mobile
                 // 60 seconds will be ignored here, because the cancelation will happen after 10 seconds
                 await Task.Delay(60000, cts.Token).ContinueWith(task => { });
 
-                if (!_discoveredDevices.ContainsKey(bluetoothAddress))
+                if (!_discoveredDevices.ContainsKey(deviceId))
                 {
                     throw new NotSupportedException("Given bt address does not belong to a discovered device");
                 }
             }
 
-            return new XamarinPoweredUpBluetoothDevice(_discoveredDevices[bluetoothAddress], _bluetoothAdapter);
+            return new XamarinPoweredUpBluetoothDevice(_discoveredDevices[deviceId], _bluetoothAdapter);
         }
 
         public Task<IPoweredUpBluetoothDeviceInfo> CreateDeviceInfoByKnownStateAsync(object state)
             => Task.FromResult<IPoweredUpBluetoothDeviceInfo>(state switch
             {
-                ulong address => new XamarinBluetoothDeviceInfo() { MacAddressAsUInt64 = address },
+                ulong address => new XamarinBluetoothDeviceInfo() { DeviceIdentifier = address.ToString() },
+                string id => new XamarinBluetoothDeviceInfo() { DeviceIdentifier = id },
                 _ => null,
             });
     }

--- a/src/SharpBrick.PoweredUp/Bluetooth/BluetoothKernel.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/BluetoothKernel.cs
@@ -9,7 +9,7 @@ namespace SharpBrick.PoweredUp.Bluetooth
     {
         private readonly ILogger _logger;
         private readonly IPoweredUpBluetoothAdapter _bluetoothAdapter;
-        public ulong BluetoothAddress { get; set; }
+        public IPoweredUpBluetoothDeviceInfo BluetoothDeviceInfo { get; set; }
         private IPoweredUpBluetoothDevice _device = null;
         private IPoweredUpBluetoothService _service = null;
         private IPoweredUpBluetoothCharacteristic _characteristic = null;
@@ -24,7 +24,7 @@ namespace SharpBrick.PoweredUp.Bluetooth
 
         public async Task ConnectAsync()
         {
-            _device = await _bluetoothAdapter.GetDeviceAsync(BluetoothAddress);
+            _device = await _bluetoothAdapter.GetDeviceAsync(BluetoothDeviceInfo);
             _service = await _device.GetServiceAsync(new Guid(PoweredUpBluetoothConstants.LegoHubService));
             _characteristic = await _service.GetCharacteristicAsync(new Guid(PoweredUpBluetoothConstants.LegoHubCharacteristic));
 

--- a/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothAdapter.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothAdapter.cs
@@ -6,8 +6,10 @@ namespace SharpBrick.PoweredUp.Bluetooth
 {
     public interface IPoweredUpBluetoothAdapter
     {
-        void Discover(Func<PoweredUpBluetoothDeviceInfo, Task> discoveryHandler, CancellationToken cancellationToken = default);
+        void Discover(Func<IPoweredUpBluetoothDeviceInfo, Task> discoveryHandler, CancellationToken cancellationToken = default);
 
-        Task<IPoweredUpBluetoothDevice> GetDeviceAsync(ulong bluetoothAddress);
+        Task<IPoweredUpBluetoothDevice> GetDeviceAsync(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo);
+
+        Task<IPoweredUpBluetoothDeviceInfo> CreateDeviceInfoByKnownStateAsync(object state);
     }
 }

--- a/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothDeviceInfo.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace SharpBrick.PoweredUp.Bluetooth
+{
+    public interface IPoweredUpBluetoothDeviceInfo : IEquatable<IPoweredUpBluetoothDeviceInfo>
+    {
+        string Name { get; }
+        byte[] ManufacturerData { get; }
+    }
+}

--- a/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothDeviceInfoWithMacAddress.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothDeviceInfoWithMacAddress.cs
@@ -1,0 +1,7 @@
+namespace SharpBrick.PoweredUp.Bluetooth
+{
+    public interface IPoweredUpBluetoothDeviceInfoWithMacAddress
+    {
+        byte[] MacAddress { get; }
+    }
+}

--- a/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothDeviceInfoWithMacAddress.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/IPoweredUpBluetoothDeviceInfoWithMacAddress.cs
@@ -1,7 +1,15 @@
+using System.Linq;
+
 namespace SharpBrick.PoweredUp.Bluetooth
 {
     public interface IPoweredUpBluetoothDeviceInfoWithMacAddress
     {
         byte[] MacAddress { get; }
+    }
+
+    public static class IPoweredUpBluetoothDeviceInfoWithMacAddressExtensions
+    {
+        public static string ToIdentificationString(this IPoweredUpBluetoothDeviceInfoWithMacAddress self)
+            => string.Join(":", self.MacAddress.Select(b => b.ToString("X2")).ToArray());
     }
 }

--- a/src/SharpBrick.PoweredUp/Bluetooth/Mock/PoweredUpBluetoothAdapterMock.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/Mock/PoweredUpBluetoothAdapterMock.cs
@@ -17,12 +17,17 @@ namespace SharpBrick.PoweredUp.Bluetooth.Mock
         public PoweredUpBluetoothServiceMock MockService { get; }
         public PoweredUpBluetoothCharacteristicMock MockCharacteristic { get; }
 
-        public void Discover(Func<PoweredUpBluetoothDeviceInfo, Task> discoveryHandler, CancellationToken cancellationToken = default)
+        public Task<IPoweredUpBluetoothDeviceInfo> CreateDeviceInfoByKnownStateAsync(object state)
+        {
+            return Task.FromResult<IPoweredUpBluetoothDeviceInfo>(new PoweredUpBluetoothDeviceInfoWithMacAddress());
+        }
+
+        public void Discover(Func<IPoweredUpBluetoothDeviceInfo, Task> discoveryHandler, CancellationToken cancellationToken = default)
         {
             throw new NotImplementedException();
         }
 
-        public Task<IPoweredUpBluetoothDevice> GetDeviceAsync(ulong bluetoothAddress)
+        public Task<IPoweredUpBluetoothDevice> GetDeviceAsync(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo)
         {
             return Task.FromResult<IPoweredUpBluetoothDevice>(MockDevice);
         }

--- a/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpBluetoothDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpBluetoothDeviceInfo.cs
@@ -1,9 +1,0 @@
-namespace SharpBrick.PoweredUp.Bluetooth
-{
-    public sealed class PoweredUpBluetoothDeviceInfo
-    {
-        public ulong BluetoothAddress { get; set; }
-        public byte[] ManufacturerData { get; set; }
-        public string Name { get; set; }
-    }
-}

--- a/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace SharpBrick.PoweredUp.Bluetooth
+{
+    public class PoweredUpBluetoothDeviceInfoWithMacAddress : IPoweredUpBluetoothDeviceInfo, IPoweredUpBluetoothDeviceInfoWithMacAddress
+    {
+        public string Name { get; set; }
+        public byte[] ManufacturerData { get; set; }
+
+        public byte[] MacAddress => new byte[1] { 99 };
+
+        public ulong MacAddressAsUInt64 { get; set; }
+
+        public bool Equals(IPoweredUpBluetoothDeviceInfo other)
+        {
+            if (other != null && other is PoweredUpBluetoothDeviceInfoWithMacAddress otherMacAddress)
+            {
+                return this.MacAddressAsUInt64 == otherMacAddress.MacAddressAsUInt64;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public override int GetHashCode()
+            => MacAddressAsUInt64.GetHashCode();
+    }
+}

--- a/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 namespace SharpBrick.PoweredUp.Bluetooth
 {
@@ -7,7 +8,7 @@ namespace SharpBrick.PoweredUp.Bluetooth
         public string Name { get; set; }
         public byte[] ManufacturerData { get; set; }
 
-        public byte[] MacAddress => new byte[1] { 99 };
+        public byte[] MacAddress => UInt64MacAddressToByteArray(MacAddressAsUInt64);
 
         public ulong MacAddressAsUInt64 { get; set; }
 
@@ -25,5 +26,22 @@ namespace SharpBrick.PoweredUp.Bluetooth
 
         public override int GetHashCode()
             => MacAddressAsUInt64.GetHashCode();
+
+
+        /// <summary>
+        /// Convert a UInt64 into a Byte Array while keeping endianess out of the game.
+        /// </summary>
+        /// <param name="myulong">the ulong to be converted</param>
+        /// <returns></returns>
+        private static byte[] UInt64MacAddressToByteArray(ulong myulong)
+        {
+            var result = new byte[6];
+            for (var i = 5; i >= 0; i--)
+            {
+                result[i] = (byte)(myulong % 256);
+                myulong /= 256;
+            }
+            return result;
+        }
     }
 }

--- a/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Linq;
+using SharpBrick.PoweredUp.Utils;
 
 namespace SharpBrick.PoweredUp.Bluetooth
 {
@@ -8,7 +7,7 @@ namespace SharpBrick.PoweredUp.Bluetooth
         public string Name { get; set; }
         public byte[] ManufacturerData { get; set; }
 
-        public byte[] MacAddress => UInt64MacAddressToByteArray(MacAddressAsUInt64);
+        public byte[] MacAddress => BytesStringUtil.UInt64MacAddressToByteArray(MacAddressAsUInt64);
 
         public ulong MacAddressAsUInt64 { get; set; }
 
@@ -26,22 +25,5 @@ namespace SharpBrick.PoweredUp.Bluetooth
 
         public override int GetHashCode()
             => MacAddressAsUInt64.GetHashCode();
-
-
-        /// <summary>
-        /// Convert a UInt64 into a Byte Array while keeping endianess out of the game.
-        /// </summary>
-        /// <param name="myulong">the ulong to be converted</param>
-        /// <returns></returns>
-        private static byte[] UInt64MacAddressToByteArray(ulong myulong)
-        {
-            var result = new byte[6];
-            for (var i = 5; i >= 0; i--)
-            {
-                result[i] = (byte)(myulong % 256);
-                myulong /= 256;
-            }
-            return result;
-        }
     }
 }

--- a/src/SharpBrick.PoweredUp/PoweredUpHost.cs
+++ b/src/SharpBrick.PoweredUp/PoweredUpHost.cs
@@ -17,7 +17,7 @@ namespace SharpBrick.PoweredUp
         private readonly IPoweredUpBluetoothAdapter _bluetoothAdapter;
         public IServiceProvider ServiceProvider { get; }
         private readonly ILogger<PoweredUpHost> _logger;
-        private readonly ConcurrentBag<(PoweredUpBluetoothDeviceInfo Info, Hub Hub)> _hubs = new();
+        private readonly ConcurrentBag<(IPoweredUpBluetoothDeviceInfo Info, Hub Hub)> _hubs = new();
 
         public IEnumerable<Hub> Hubs => _hubs.Select(i => i.Hub);
 
@@ -33,8 +33,8 @@ namespace SharpBrick.PoweredUp
         public THub FindByType<THub>() where THub : Hub
             => Hubs.OfType<THub>().FirstOrDefault();
 
-        public THub Find<THub>(ulong bluetoothAddress) where THub : Hub
-            => _hubs.Where(h => h.Info.BluetoothAddress == bluetoothAddress).Select(i => i.Hub).FirstOrDefault() as THub;
+        public THub Find<THub>(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo) where THub : Hub
+            => _hubs.Where(h => h.Info.Equals(bluetoothDeviceInfo)).Select(i => i.Hub).FirstOrDefault() as THub;
 
         public THub FindById<THub>(byte hubId) where THub : Hub, IDisposable
             => _hubs.Where(h => h.Hub.HubId == hubId).Select(i => i.Hub).FirstOrDefault() as THub;
@@ -47,13 +47,15 @@ namespace SharpBrick.PoweredUp
             {
                 try
                 {
-                    if (!_hubs.Any(i => i.Info.BluetoothAddress == deviceInfo.BluetoothAddress))
+                    if (!_hubs.Any(i => i.Info.Equals(deviceInfo)))
                     {
-                        var hub = CreateHubInBluetoothScope(deviceInfo.BluetoothAddress, hubFactory => hubFactory.CreateByBluetoothManufacturerData(deviceInfo.ManufacturerData));
+                        var hub = CreateHubInBluetoothScope(deviceInfo, hubFactory => hubFactory.CreateByBluetoothManufacturerData(deviceInfo.ManufacturerData));
 
                         _hubs.Add((deviceInfo, hub));
 
-                        _logger.LogInformation($"Discovered log of type {hub.GetType().Name} with name '{deviceInfo.Name}' on Bluetooth Address '{deviceInfo.BluetoothAddress}'");
+                        var text = (deviceInfo is IPoweredUpBluetoothDeviceInfoWithMacAddress mac) ? mac.MacAddress[0].ToString() : "not revealed";
+
+                        _logger.LogInformation($"Discovered log of type {hub.GetType().Name} with name '{deviceInfo.Name}' on Bluetooth Address '{text}'");
 
                         await onDiscovery(hub);
                     }
@@ -95,44 +97,41 @@ namespace SharpBrick.PoweredUp
             return hub;
         }
 
-        public THub Create<THub>(ulong bluetoothAddress) where THub : Hub
+        public async Task<THub> CreateByStateAsync<THub>(object bluetoothDeviceInfoState) where THub : Hub
         {
-            var hub = CreateHubInBluetoothScope(bluetoothAddress, hubFactory => hubFactory.Create<THub>());
+            var deviceInfo = await _bluetoothAdapter.CreateDeviceInfoByKnownStateAsync(bluetoothDeviceInfoState);
 
-            _hubs.Add((new PoweredUpBluetoothDeviceInfo()
-            {
-                BluetoothAddress = bluetoothAddress,
-                Name = string.Empty,
-                ManufacturerData = Array.Empty<byte>(),
-            }, hub));
+            var hub = CreateHubInBluetoothScope(deviceInfo, hubFactory => hubFactory.Create<THub>());
+
+            _hubs.Add((deviceInfo, hub));
 
             return hub;
         }
 
-        public ILegoWirelessProtocol CreateProtocol(ulong bluetoothAddress)
+        public ILegoWirelessProtocol CreateProtocol(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo)
         {
-            var protocolScope = CreateProtocolScope(bluetoothAddress);
+            var protocolScope = CreateProtocolScope(bluetoothDeviceInfo);
 
             var protocol = protocolScope.ServiceProvider.GetService<ILegoWirelessProtocol>();
 
             return protocol;
         }
 
-        public IServiceScope CreateProtocolScope(ulong bluetoothAddress)
+        public IServiceScope CreateProtocolScope(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo)
         {
             var scope = ServiceProvider.CreateScope();
             var scopedServiceProvider = scope.ServiceProvider;
 
             // initialize scoped bluetooth kernel to bluetooth address.
             var kernel = scopedServiceProvider.GetService<BluetoothKernel>();
-            kernel.BluetoothAddress = bluetoothAddress;
+            kernel.BluetoothDeviceInfo = bluetoothDeviceInfo;
 
             return scope;
         }
 
-        private THub CreateHubInBluetoothScope<THub>(ulong bluetoothAddress, Func<IHubFactory, THub> factory) where THub : Hub
+        private THub CreateHubInBluetoothScope<THub>(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo, Func<IHubFactory, THub> factory) where THub : Hub
         {
-            var protocolScope = CreateProtocolScope(bluetoothAddress);
+            var protocolScope = CreateProtocolScope(bluetoothDeviceInfo);
 
             var hubFactory = protocolScope.ServiceProvider.GetService<IHubFactory>();
 

--- a/src/SharpBrick.PoweredUp/PoweredUpHost.cs
+++ b/src/SharpBrick.PoweredUp/PoweredUpHost.cs
@@ -53,7 +53,7 @@ namespace SharpBrick.PoweredUp
 
                         _hubs.Add((deviceInfo, hub));
 
-                        var text = (deviceInfo is IPoweredUpBluetoothDeviceInfoWithMacAddress mac) ? mac.MacAddress[0].ToString() : "not revealed";
+                        var text = (deviceInfo is IPoweredUpBluetoothDeviceInfoWithMacAddress mac) ? mac.ToIdentificationString() : "not revealed";
 
                         _logger.LogInformation($"Discovered log of type {hub.GetType().Name} with name '{deviceInfo.Name}' on Bluetooth Address '{text}'");
 

--- a/src/SharpBrick.PoweredUp/Utils/BytesStringUtil.cs
+++ b/src/SharpBrick.PoweredUp/Utils/BytesStringUtil.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Linq;
 
@@ -7,10 +8,37 @@ namespace SharpBrick.PoweredUp.Utils
     {
         public static string DataToString(byte[] data)
             => string.Join("-", data.Select(b => $"{b:X2}"));
+
         public static byte[] StringToData(string messageAsString)
             => messageAsString.Split("-").Select(s => byte.Parse(s, NumberStyles.HexNumber)).ToArray();
 
         public static string ToBitString(ushort data)
             => new(Enumerable.Range(0, 16).Reverse().Select(idx => (((1 << idx) & data) > 0) ? '1' : '0').ToArray());
+
+        public static string ByteArrayToHexString(byte[] byteArray, string separator = ":")
+            => string.Join(separator, byteArray.Select(b => b.ToString("X2")).ToArray());
+
+        public static byte[] HexStringToByteArray(string hexString, string separator = ":")
+            => hexString.Split(separator).Select(x => Convert.ToByte(x, 16)).ToArray();
+        
+        public static ulong HexStringToUInt64(string hexString, string separator = ":")
+            => Convert.ToUInt64(hexString.Replace(separator, ""), 16);
+
+        /// <summary>
+        /// Convert a UInt64 into a Byte Array while keeping endianess out of the game.
+        /// </summary>
+        /// <param name="myulong">the ulong to be converted</param>
+        /// <returns></returns>
+        public static byte[] UInt64MacAddressToByteArray(ulong myulong)
+        {
+            var result = new byte[6];
+            for (var i = 5; i >= 0; i--)
+            {
+                result[i] = (byte)(myulong % 256);
+                myulong /= 256;
+            }
+            return result;
+        }
+
     }
 }


### PR DESCRIPTION
- Abstract identity in an interface independent of Mac Address
- Change PoweredUpHost function to use generic state instead
  of bluetooth address as ulong
- Implement interface in existing adapters (simple transformation)
- Change BluetoothKernel interface to accept device instead of
  bluetooth address
- Add formatting to the MAC Address DeviceInfo

Closes #154