### PR TITLE
Issue 154 deviceinfo adjustements

### DIFF
--- a/src/SharpBrick.PoweredUp.Mobile/NativeDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/NativeDeviceInfo.cs
@@ -2,7 +2,15 @@
 {
     public class NativeDeviceInfo
     {
-        public string MacAddress { get; set; }
+        /// <summary>
+        /// In Android, the MacAddressString will be returned
+        /// In iOS the unique identifier is used
+        /// </summary>
+        public string DeviceIdentifier { get; set; }
+
+        public byte[] MacAddress { get; set; }
+     
+        public string MacAddressString { get; set; }
 
         public ulong MacAddressNumeric { get; set; }
     }

--- a/src/SharpBrick.PoweredUp.Mobile/NativeDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/NativeDeviceInfo.cs
@@ -7,11 +7,5 @@
         /// In iOS the unique identifier is used
         /// </summary>
         public string DeviceIdentifier { get; set; }
-
-        public byte[] MacAddress { get; set; }
-     
-        public string MacAddressString { get; set; }
-
-        public ulong MacAddressNumeric { get; set; }
     }
 }

--- a/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
@@ -1,17 +1,19 @@
-using System;
 using SharpBrick.PoweredUp.Bluetooth;
 
 namespace SharpBrick.PoweredUp.Mobile
 {
     public class XamarinBluetoothDeviceInfo : IPoweredUpBluetoothDeviceInfo, IPoweredUpBluetoothDeviceInfoWithMacAddress
     {
+        public string DeviceIdentifier { get; set; }
+
         public string Name { get; set; }
+        
         public byte[] ManufacturerData { get; set; }
 
-        public byte[] MacAddress => throw new NotImplementedException();
+        public byte[] MacAddress { get; set; }
 
         public ulong MacAddressAsUInt64 { get; set; }
-
+    
         public bool Equals(IPoweredUpBluetoothDeviceInfo other)
         {
             if (other != null && other is XamarinBluetoothDeviceInfo otherXamarin)

--- a/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/XamarinBluetoothDeviceInfo.cs
@@ -1,30 +1,69 @@
+using System;
+using System.Runtime.InteropServices;
 using SharpBrick.PoweredUp.Bluetooth;
+using SharpBrick.PoweredUp.Utils;
 
 namespace SharpBrick.PoweredUp.Mobile
 {
     public class XamarinBluetoothDeviceInfo : IPoweredUpBluetoothDeviceInfo, IPoweredUpBluetoothDeviceInfoWithMacAddress
     {
-        public string DeviceIdentifier { get; set; }
+        private string _deviceIdentifier;
+
+        public string DeviceIdentifier
+        {
+            get => _deviceIdentifier;
+            set
+            {
+                _deviceIdentifier = value;
+                UpdateMacAddress();
+            }
+        }
 
         public string Name { get; set; }
         
         public byte[] ManufacturerData { get; set; }
 
-        public byte[] MacAddress { get; set; }
+        public byte[] MacAddress { get; private set; } = new byte[0];
 
-        public ulong MacAddressAsUInt64 { get; set; }
-    
+        public ulong MacAddressAsUInt64 { get; private set; } = 0;
+
         public bool Equals(IPoweredUpBluetoothDeviceInfo other)
         {
             if (other != null && other is XamarinBluetoothDeviceInfo otherXamarin)
             {
-                return this.MacAddressAsUInt64 == otherXamarin.MacAddressAsUInt64;
+                return this.DeviceIdentifier == otherXamarin.DeviceIdentifier;
             }
             else
             {
                 return false;
             }
         }
+
+        private void UpdateMacAddress()
+        {
+            if (string.IsNullOrWhiteSpace(_deviceIdentifier)) return;
+
+            if (Guid.TryParse(_deviceIdentifier, out Guid result))
+            {
+                // we're on an iOS device -> no mac address is revealed
+                return;
+            }
+
+            if (_deviceIdentifier.Contains(":"))
+            {
+                MacAddress = BytesStringUtil.HexStringToByteArray(_deviceIdentifier);
+                MacAddressAsUInt64 = BytesStringUtil.HexStringToUInt64(_deviceIdentifier);
+                return;
+            }
+
+            if (ulong.TryParse(_deviceIdentifier, out ulong macAdressAsUlong))
+            {
+                MacAddressAsUInt64 = macAdressAsUlong;
+                MacAddress = BytesStringUtil.UInt64MacAddressToByteArray(macAdressAsUlong);
+                _deviceIdentifier = BytesStringUtil.ByteArrayToHexString(MacAddress);
+            }
+        }
+        
     }
 
 }

--- a/src/SharpBrick.PoweredUp.Mobile/XamarinPoweredUpBluetoothAdapter.cs
+++ b/src/SharpBrick.PoweredUp.Mobile/XamarinPoweredUpBluetoothAdapter.cs
@@ -51,8 +51,6 @@ namespace SharpBrick.PoweredUp.Mobile
                     var nativeDeviceInfo = _deviceInfoProvider.GetNativeDeviceInfo(args.Device.NativeDevice);
 
                     info.Name = args.Device.Name;
-                    info.MacAddressAsUInt64 = nativeDeviceInfo.MacAddressNumeric;
-                    info.MacAddress = nativeDeviceInfo.MacAddress;
                     info.DeviceIdentifier= nativeDeviceInfo.DeviceIdentifier;
 
                     AddInternalDevice(args.Device, info);
@@ -127,7 +125,7 @@ namespace SharpBrick.PoweredUp.Mobile
         public Task<IPoweredUpBluetoothDeviceInfo> CreateDeviceInfoByKnownStateAsync(object state)
             => Task.FromResult<IPoweredUpBluetoothDeviceInfo>(state switch
             {
-                ulong address => new XamarinBluetoothDeviceInfo() { MacAddressAsUInt64 = address },
+                ulong address => new XamarinBluetoothDeviceInfo() { DeviceIdentifier = address.ToString() },
                 string id => new XamarinBluetoothDeviceInfo() { DeviceIdentifier = id },
                 _ => null,
             });

--- a/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
+++ b/src/SharpBrick.PoweredUp/Bluetooth/PoweredUpDeviceInfoWithMacAddress.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Linq;
+using SharpBrick.PoweredUp.Utils;
 
 namespace SharpBrick.PoweredUp.Bluetooth
 {
@@ -8,7 +7,7 @@ namespace SharpBrick.PoweredUp.Bluetooth
         public string Name { get; set; }
         public byte[] ManufacturerData { get; set; }
 
-        public byte[] MacAddress => UInt64MacAddressToByteArray(MacAddressAsUInt64);
+        public byte[] MacAddress => BytesStringUtil.UInt64MacAddressToByteArray(MacAddressAsUInt64);
 
         public ulong MacAddressAsUInt64 { get; set; }
 
@@ -26,22 +25,5 @@ namespace SharpBrick.PoweredUp.Bluetooth
 
         public override int GetHashCode()
             => MacAddressAsUInt64.GetHashCode();
-
-
-        /// <summary>
-        /// Convert a UInt64 into a Byte Array while keeping endianess out of the game.
-        /// </summary>
-        /// <param name="myulong">the ulong to be converted</param>
-        /// <returns></returns>
-        private static byte[] UInt64MacAddressToByteArray(ulong myulong)
-        {
-            var result = new byte[6];
-            for (var i = 5; i >= 0; i--)
-            {
-                result[i] = (byte)(myulong % 256);
-                myulong /= 256;
-            }
-            return result;
-        }
     }
 }

--- a/src/SharpBrick.PoweredUp/Utils/BytesStringUtil.cs
+++ b/src/SharpBrick.PoweredUp/Utils/BytesStringUtil.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Linq;
 
@@ -7,10 +8,37 @@ namespace SharpBrick.PoweredUp.Utils
     {
         public static string DataToString(byte[] data)
             => string.Join("-", data.Select(b => $"{b:X2}"));
+
         public static byte[] StringToData(string messageAsString)
             => messageAsString.Split("-").Select(s => byte.Parse(s, NumberStyles.HexNumber)).ToArray();
 
         public static string ToBitString(ushort data)
             => new(Enumerable.Range(0, 16).Reverse().Select(idx => (((1 << idx) & data) > 0) ? '1' : '0').ToArray());
+
+        public static string ByteArrayToHexString(byte[] byteArray, string separator = ":")
+            => string.Join(separator, byteArray.Select(b => b.ToString("X2")).ToArray());
+
+        public static byte[] HexStringToByteArray(string hexString, string separator = ":")
+            => hexString.Split(separator).Select(x => Convert.ToByte(x, 16)).ToArray();
+        
+        public static ulong HexStringToUInt64(string hexString, string separator = ":")
+            => Convert.ToUInt64(hexString.Replace(separator, ""), 16);
+
+        /// <summary>
+        /// Convert a UInt64 into a Byte Array while keeping endianess out of the game.
+        /// </summary>
+        /// <param name="myulong">the ulong to be converted</param>
+        /// <returns></returns>
+        public static byte[] UInt64MacAddressToByteArray(ulong myulong)
+        {
+            var result = new byte[6];
+            for (var i = 5; i >= 0; i--)
+            {
+                result[i] = (byte)(myulong % 256);
+                myulong /= 256;
+            }
+            return result;
+        }
+
     }
 }


### PR DESCRIPTION
Hi @tthiery,

I reworked the xamarin deviceinfo a little bit. 
Perhaps having a string deviceIdentifier might not be the best solution but currently works the following way:
* IOS sets the NSUuid (GUID) as DeviceIdentifier (can be used to directly connect to the device)
* Android sets the MacAddress as string as DeviceIdentifier ("xx:xx:xx:xx:xx:xx")
* the XamarinBluetoothDeviceInfo will handle these infos and try to set the corresponding mac adress
* IOS has the limitations, that you need to know the NSUuid if you want to connect to "known" device
* I extended the BytesStringUtil class with some more conversions so we should rename the class perhaps to ConversionUtil
* I will adjust the open pull request in [example-xamarin](https://github.com/sharpbrick/example-xamarin/pull/1)