### PR TITLE
Generate XML documentation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,5 +6,7 @@
    <PackageProjectUrl>https://github.com/sharpbrick/powered-up</PackageProjectUrl>
    <RepositoryUrl>https://github.com/sharpbrick/powered-up</RepositoryUrl>
    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+   <GenerateDocumentationFile>true</GenerateDocumentationFile>
+   <NoWarn>$(NoWarn);CS1591</NoWarn>
  </PropertyGroup>
 </Project>

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaBLEHelper.cs
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaBLEHelper.cs
@@ -107,7 +107,7 @@ public class BlueGigaBLEHelper
     /// <summary>
     /// Convert a ulong into a BYte-Array
     /// </summary>
-    /// <param name="myulong">the ulong to be converted</param>
+    /// <param name="mybytes">the byte[] to be converted</param>
     /// <returns></returns>
     public static ulong ByteArrayToUlong(byte[] mybytes)
     {

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaBLEPoweredUpBluetoothAdapater.cs
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaBLEPoweredUpBluetoothAdapater.cs
@@ -133,7 +133,7 @@ public class BlueGigaBLEPoweredUpBluetoothAdapater : IPoweredUpBluetoothAdapter,
     /// <summary>
     /// Get the device given by the bluetooth-address (ulong) and discover all services and their characteristics. The  device is connected after this call!
     /// </summary>
-    /// <param name="bluetoothAddress"></param>
+    /// <param name="bluetoothDeviceInfo"></param>
     /// <returns></returns>
     public async Task<IPoweredUpBluetoothDevice> GetDeviceAsync(IPoweredUpBluetoothDeviceInfo bluetoothDeviceInfo)
     {

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaBLEPoweredUpBluetoothService.cs
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/BlueGigaBLEPoweredUpBluetoothService.cs
@@ -43,6 +43,8 @@ public class BlueGigaBLEPoweredUpBluetoothService : IPoweredUpBluetoothService, 
     /// <param name="serviceUuid">The service-UUID of this service</param>
     /// <param name="firstCharacterHandle">The first handle under which the service has a characteristic</param>
     /// <param name="lastCharacterHandle">The last handle under which the service has a characteristic</param>
+    /// <param name="logger"></param>
+    /// <param name="traceDebug"></param>
     public BlueGigaBLEPoweredUpBluetoothService(BlueGigaBLEPoweredUpBluetoothDevice device, Guid serviceUuid, ushort firstCharacterHandle, ushort lastCharacterHandle, ILogger logger, bool traceDebug)
     {
         Device = device ?? throw new ArgumentNullException(nameof(device));

--- a/src/SharpBrick.PoweredUp.BlueGigaBLE/IBlueGigaLogger.cs
+++ b/src/SharpBrick.PoweredUp.BlueGigaBLE/IBlueGigaLogger.cs
@@ -18,6 +18,8 @@ public interface IBlueGigaLogger
     /// Writes the indented information of this object into the configured ILogger
     /// </summary>
     /// <param name="indent"></param>
+    /// <param name="header"></param>
+    /// <param name="footer"></param>
     public Task LogInfosAsync(int indent = 0, string header = "", string footer = "");
     /// <summary>
     /// Shall the LogInfoAsync really log

--- a/src/SharpBrick.PoweredUp/Deployment/DeploymentModelBuilder.cs
+++ b/src/SharpBrick.PoweredUp/Deployment/DeploymentModelBuilder.cs
@@ -53,8 +53,7 @@ public class DeploymentModelBuilder
     /// <summary>
     /// Adds a hub to the model
     /// </summary>
-    /// <param name="hubType"></param>
-    /// <param name="devices"></param>
+    /// <param name="hubModel"></param>
     /// <returns></returns>
     private DeploymentModelBuilder AddHub(DeploymentHubModel hubModel)
     {

--- a/src/SharpBrick.PoweredUp/Deployment/HubExtensions.cs
+++ b/src/SharpBrick.PoweredUp/Deployment/HubExtensions.cs
@@ -31,7 +31,7 @@ public static class HubExtensions
     /// Verifies the deployment model and waits till it reaches zero deployment errors.
     /// </summary>
     /// <param name="self"></param>
-    /// <param name="configure">Builder infrastructure for the deployment model</param>
+    /// <param name="model">Deployment Model</param>
     /// <returns></returns>
     public static async Task VerifyDeploymentModelAsync(this Hub self, DeploymentModel model)
     {


### PR DESCRIPTION
I noticed, that there is no XML documentation in the NuGet packages.

I'm adding it globally (in the `Directory.Build.props`) and disable warnings about missing XML comments for public types or members ([CS1591](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs1591)).


#205 non-breaking