### PR TITLE
Update GitHub actions to latest versions

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - master
     tags:
-      - '!v*'
+      - "!v*"
   pull_request:
 
 env:
-  # Set the DOTNET_SKIP_FIRST_TIME_EXPERIENCE environment variable to stop wasting time caching packages
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  # Disable the .NET logo in the console output
+  DOTNET_NOLOGO: true
   # Disable sending usage data to Microsoft
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
@@ -18,32 +18,30 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.100
-    - name: Build SharpBrick.PoweredUp
-      run: dotnet build --configuration Release
-    - name: Test SharpBrick.PoweredUp
-      run: dotnet test --no-build --configuration Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov
-      #run: dotnet test --no-build --configuration Release --logger trx
-    - name: Code Coverage ReportGenerator
-      uses: danielpalme/ReportGenerator-GitHub-Action@4.6.1
-      with:
-        reports: 'test/SharpBrick.PoweredUp.Test/TestResults/coverage.info' # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
-        targetdir: './artifacts/coveragereport' # REQUIRED # The directory where the generated report should be saved.
-        reporttypes: 'HtmlInline;Cobertura' # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, Xml, XmlSummary
-        sourcedirs: '' # Optional directories which contain the corresponding source code (separated by semicolon). The source directories are used if coverage report contains classes without path information.
-        historydir: '' # Optional directory for storing persistent coverage information. Can be used in future reports to show coverage evolution.
-        plugins: '' # Optional plugin files for custom reports or custom history storage (separated by semicolon).
-        assemblyfilters: '+*' # Optional list of assemblies that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-        classfilters: '+*' # Optional list of classes that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-        filefilters: '+*' # Optional list of files that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
-        verbosity: 'Info' # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
-        title: '' # Optional title.
-        tag: '${{ github.run_number }}_${{ github.run_id }}' # Optional tag or build version.
-    - uses: actions/upload-artifact@v4
-      with:
-        name: artifacts
-        path: ./artifacts
+      - uses: actions/checkout@v6
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+      - name: Build SharpBrick.PoweredUp
+        run: dotnet build --configuration Release
+      - name: Test SharpBrick.PoweredUp
+        run: dotnet test --no-build --configuration Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=lcov
+        #run: dotnet test --no-build --configuration Release --logger trx
+      - name: Code Coverage ReportGenerator
+        uses: danielpalme/ReportGenerator-GitHub-Action@4.6.1
+        with:
+          reports: "test/SharpBrick.PoweredUp.Test/TestResults/coverage.info" # REQUIRED # The coverage reports that should be parsed (separated by semicolon). Globbing is supported.
+          targetdir: "./artifacts/coveragereport" # REQUIRED # The directory where the generated report should be saved.
+          reporttypes: "HtmlInline;Cobertura" # The output formats and scope (separated by semicolon) Values: Badges, Clover, Cobertura, CsvSummary, Html, HtmlChart, HtmlInline, HtmlInline_AzurePipelines, HtmlInline_AzurePipelines_Dark, HtmlSummary, JsonSummary, Latex, LatexSummary, lcov, MHtml, PngChart, SonarQube, TeamCitySummary, TextSummary, Xml, XmlSummary
+          sourcedirs: "" # Optional directories which contain the corresponding source code (separated by semicolon). The source directories are used if coverage report contains classes without path information.
+          historydir: "" # Optional directory for storing persistent coverage information. Can be used in future reports to show coverage evolution.
+          plugins: "" # Optional plugin files for custom reports or custom history storage (separated by semicolon).
+          assemblyfilters: "+*" # Optional list of assemblies that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+          classfilters: "+*" # Optional list of classes that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+          filefilters: "+*" # Optional list of files that should be included or excluded in the report. Exclusion filters take precedence over inclusion filters. Wildcards are allowed.
+          verbosity: "Info" # The verbosity level of the log messages. Values: Verbose, Info, Warning, Error, Off
+          title: "" # Optional title.
+          tag: "${{ github.run_number }}_${{ github.run_id }}" # Optional tag or build version.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: artifacts
+          path: ./artifacts

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -6,46 +6,45 @@ on:
   release:
     types: [published]
 
+env:
+  # Disable the .NET logo in the console output
+  DOTNET_NOLOGO: true
+  # Disable sending usage data to Microsoft
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
 jobs:
   build:
     runs-on: windows-latest
-    env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: 1
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.100
-    - name: Build Version
-      # run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:11}) // deprecated
-      run: echo "RELEASE_VERSION=$($env:GITHUB_REF.SubString(11))" >> $env:GITHUB_ENV
-    - name: Build Project
-      run: dotnet build --configuration Release -p:Version=$env:RELEASE_VERSION
-    - name: Test Project
-      run: dotnet test --no-build --configuration Release --logger trx
-    - name: Pack Project
-      run: dotnet pack --no-build --output ./artifacts --configuration Release -p:Version=$env:RELEASE_VERSION
-    - uses: actions/upload-artifact@v4
-      with:
-        name: artifacts
-        path: ./artifacts
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
+      - name: Build Version
+        run: echo "RELEASE_VERSION=$($env:GITHUB_REF.SubString(11))" >> $env:GITHUB_ENV
+      - name: Build Project
+        run: dotnet build --configuration Release -p:Version=$env:RELEASE_VERSION
+      - name: Test Project
+        run: dotnet test --no-build --configuration Release --logger trx
+      - name: Pack Project
+        run: dotnet pack --no-build --output ./artifacts --configuration Release -p:Version=$env:RELEASE_VERSION
+      - uses: actions/upload-artifact@v7
+        with:
+          name: artifacts
+          path: ./artifacts
   publish-nuget:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
-    needs: [ build ]
-    env:
-      DOTNET_CLI_TELEMETRY_OPTOUT: 1
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_APIKEY }}
+    needs: [build]
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 8.0.100
-        source-url: https://api.nuget.org/v3/index.json
-    - uses: actions/download-artifact@v4
-      with:
-        name: artifacts
-        path: ./artifacts
-    - name: Upload to NuGet
-      run:  dotnet nuget push ./artifacts/**/*.nupkg --skip-duplicate -n -k $NUGET_AUTH_TOKEN
+      - uses: actions/checkout@v6
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          source-url: https://api.nuget.org/v3/index.json
+      - uses: actions/download-artifact@v8
+        with:
+          name: artifacts
+          path: ./artifacts
+      - name: Upload to NuGet
+        run: dotnet nuget push ./artifacts/**/*.nupkg --skip-duplicate -n -k $NUGET_AUTH_TOKEN
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_APIKEY }}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
The noteworthy changes (other than version bumps) are:
- Use [`DOTNET_NOLOGO`](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_nologo) instead of `DOTNET_SKIP_FIRST_TIME_EXPERIENCE`
- Use a [`global.json`](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json) file to set the .NET SDK version (ensures that local builds behave the same as CI builds)

What did not yet get updated is the [danielpalme/ReportGenerator-GitHub-Action](https://github.com/danielpalme/ReportGenerator-GitHub-Action), because that will most likely require changes to the test projects.

#205 non-breaking